### PR TITLE
Allow chains of member calls

### DIFF
--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -14,24 +14,20 @@ const importLocalName = (name, state) => {
 }
 
 export const isStyled = (tag, state) => {
-  return (
-    (t.isMemberExpression(tag) && tag.object.name === importLocalName('default', state)) ||
-    (t.isCallExpression(tag) && tag.callee.name === importLocalName('default', state))
-  )
+  if (t.isCallExpression(tag) && t.isMemberExpression(tag.callee)) {
+    // styled.something()
+    return isStyled(tag.callee.object, state)
+  } else {
+    return (
+      (t.isMemberExpression(tag) && tag.object.name === importLocalName('default', state)) ||
+      (t.isCallExpression(tag) && tag.callee.name === importLocalName('default', state))
+    )
+  }
 }
 
 export const isHelper = (tag, state) => {
   return t.isIdentifier(tag) && (
     tag.name === importLocalName('css', state) ||
     tag.name === importLocalName('keyframes', state)
-  )
-}
-
-export const isConfiguredStyled = (tag, state) => {
-  return (
-    t.isCallExpression(tag) &&
-    t.isMemberExpression(tag.callee) &&
-    tag.callee.property.name === 'withConfig' &&
-    isStyled(tag.callee.object, state)
   )
 }

--- a/src/visitors/transpileTemplateLiterals.js
+++ b/src/visitors/transpileTemplateLiterals.js
@@ -1,12 +1,11 @@
 import * as t from 'babel-types'
 import { useTranspileTemplateLiterals } from '../utils/options'
-import { isStyled, isHelper, isConfiguredStyled } from '../utils/detectors'
+import { isStyled, isHelper } from '../utils/detectors'
 
 export default (path, state) => {
   if (useTranspileTemplateLiterals(state) && (
     isStyled(path.node.tag, state) ||
-    isHelper(path.node.tag, state) ||
-    isConfiguredStyled(path.node.tag, state)
+    isHelper(path.node.tag, state)
   )) {
     const { tag: callee, quasi: { quasis, expressions }} = path.node
     const values = t.arrayExpression(quasis.map(quasi => t.stringLiteral(quasi.value.cooked)))

--- a/test/fixtures/13-allow-chains-of-member-calls/.babelrc
+++ b/test/fixtures/13-allow-chains-of-member-calls/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "ssr": false,
+      "fileName": false,
+      "transpileTemplateLiterals": false
+    }]
+  ]
+}

--- a/test/fixtures/13-allow-chains-of-member-calls/after.js
+++ b/test/fixtures/13-allow-chains-of-member-calls/after.js
@@ -1,0 +1,6 @@
+const WithAttrs = styled.div.attrs({ some: 'value' }).withConfig({
+  displayName: 'WithAttrs'
+})``;
+const WithAttrsWrapped = styled(Inner).attrs({ some: 'value' }).withConfig({
+  displayName: 'WithAttrsWrapped'
+})``;

--- a/test/fixtures/13-allow-chains-of-member-calls/before.js
+++ b/test/fixtures/13-allow-chains-of-member-calls/before.js
@@ -1,0 +1,2 @@
+const WithAttrs = styled.div.attrs({ some: 'value'})``
+const WithAttrsWrapped = styled(Inner).attrs({ some: 'value'})``


### PR DESCRIPTION
This change loosens checks to detect 
```
styled.div.attrs().anotherCall()`width: 100%;`
``` 
as styled component. I think it's a good change anyway, but besides that it allows syntax proposed in 
styled-components/styled-components#365.