### PR TITLE
[WIP] Preprocess CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.4.5",
+    "babel-jest": "^18.0.0",
     "babel-preset-env": "^1.1.8",
     "jest": "^17.0.3"
   },
@@ -31,5 +32,14 @@
     "server-side rendering",
     "ssr",
     "displayName"
-  ]
+  ],
+  "jest": {
+    "transform": {
+      ".js": "<rootDir>/node_modules/babel-jest"
+    },
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/"
+    ]
+  }
 }

--- a/src/css/parser.js
+++ b/src/css/parser.js
@@ -1,0 +1,126 @@
+const parse = css => {
+  const findToken = (needle, start, end) => {
+    let index = start;
+
+    while (
+      css[index] !== needle &&
+      index <= end
+    ) {
+      index++;
+    }
+
+    // Throw if there's no matching token
+    if (index > end) {
+      throw new Error(`Unexpected token! Unable to find matching '${needle}'.`);
+    }
+
+    return index;
+  };
+
+  const findClosingParanthesis = (start, end) => {
+    let level = 1;
+    let index;
+
+    for(
+      index = start;
+      level > 0 && index <= end;
+      index++
+    ) {
+      const token = css[index];
+
+      if (token === '{') {
+        level++;
+      } else if (token === '}') {
+        level--;
+      }
+    }
+
+    // Throw if there's no matching token
+    if (index >= end) {
+      throw new Error(`Unexpected token! Unable to find matching '}'.`);
+    }
+
+    return index;
+  };
+
+  const parseSelector = (start, end) => ({
+    type: 'SelectorLiteral',
+    loc: [start, end],
+    value: css.slice(start, end).trim()
+  });
+
+  const parseProperty = (start, end) => {
+    const value = css.slice(start, end).trim();
+
+    if (value.includes(';')) {
+      throw new Error(`Unexpected token! Properties cannot contain ';'.`);
+    } else if (/\s/g.test(value)) {
+      throw new Error(`Unexpected token! Properties cannot contain whitespaces.`);
+    }
+
+    return {
+      type: 'PropertyLiteral',
+      loc: [start, end],
+      value
+    };
+  };
+
+  const parseValue = (start, end) => ({
+    type: 'ValueLiteral',
+    loc: [start, end],
+    value: css.slice(start, end).trim()
+  });
+
+  // Parses a declaration of the form `property: value;`
+  const parseDeclaration = (start, separator, end) => ({
+    type: 'Declaration',
+    loc: [start, end],
+    property: parseProperty(start, separator),
+    value: parseValue(separator + 1, end)
+  });
+
+  // Parses a rule of the form `selector { body }`
+  const parseRule = (start, separator, end) => ({
+    type: 'Rule',
+    loc: [start, end],
+    selector: parseSelector(start, separator - 1),
+    block: parseBlock(separator + 1, end - 1)
+  });
+
+  const parseBlock = (start, end) => {
+    let _start = start;
+    let index = start;
+
+    const declarations = [];
+    const rules = [];
+
+    while (index <= end) {
+      const token = css[index];
+
+      if (token === '{') {
+        const _end = findClosingParanthesis(index + 1, end);
+        rules.push(parseRule(_start, index, _end));
+
+        index = _start = _end + 1;
+      } else if (token === ':') {
+        const _end = findToken(';', index, end);
+        declarations.push(parseDeclaration(_start, index, _end));
+
+        index = _start = _end + 1;
+      } else {
+        index++;
+      }
+    }
+
+    return {
+      type: 'Block',
+      loc: [start, end],
+      declarations,
+      rules
+    };
+  };
+
+  return parseBlock(0, css.length - 1);
+};
+
+export default parse;

--- a/src/css/parser.js
+++ b/src/css/parser.js
@@ -1,15 +1,22 @@
 import {
   findToken,
-  findClosingParanthesis
+  findClosingParanthesis,
+  filterNodesForLocation
 } from './utils/parsingUtils'
 
-export const selectorNode = (css, start, end) => ({
+export const interpolationNode = (babelNode, loc) => ({
+  type: 'Interpolation',
+  loc: [loc, loc],
+  babelNode
+})
+
+export const selectorNode = (css, interpolations, start, end) => ({
   type: 'SelectorLiteral',
   loc: [start, end],
   value: css.slice(start, end).trim()
 })
 
-export const propertyNode = (css, start, end) => {
+export const propertyNode = (css, interpolations, start, end) => {
   const value = css.slice(start, end).trim()
 
   if (value.includes(';')) {
@@ -25,29 +32,49 @@ export const propertyNode = (css, start, end) => {
   }
 }
 
-export const valueNode = (css, start, end) => ({
+export const valueNode = (css, interpolations, start, end) => ({
   type: 'ValueLiteral',
   loc: [start, end],
   value: css.slice(start, end).trim()
 })
 
 // Parses a declaration of the form `property: value`
-export const declarationNode = (css, start, separator, end) => ({
+export const declarationNode = (css, interpolations, start, separator, end) => ({
   type: 'Declaration',
   loc: [start, end],
-  property: propertyNode(css, start, separator),
-  value: valueNode(css, separator + 1, end)
+  property: propertyNode(
+    css,
+    filterNodesForLocation(interpolations, start, separator),
+    start,
+    separator
+  ),
+  value: valueNode(
+    css,
+    filterNodesForLocation(interpolations, separator + 1, end),
+    separator + 1,
+    end
+  )
 })
 
 // Parses a rule of the form `selector { body }`
-export const ruleNode = (css, start, separator, end) => ({
+export const ruleNode = (css, interpolations, start, separator, end) => ({
   type: 'Rule',
   loc: [start, end],
-  selector: selectorNode(css, start, separator - 1),
-  block: blockNode(css, separator + 1, end - 1)
+  selector: selectorNode(
+    css,
+    filterNodesForLocation(interpolations, start, separator - 1),
+    start,
+    separator - 1
+  ),
+  block: blockNode(
+    css,
+    filterNodesForLocation(interpolations, separator + 1, end - 1),
+    separator + 1,
+    end - 1
+  )
 })
 
-export const blockNode = (css, start, end) => {
+export const blockNode = (css, interpolations, start, end) => {
   let _start = start
   let index = start
 
@@ -59,12 +86,26 @@ export const blockNode = (css, start, end) => {
 
     if (token === '{') {
       const _end = findClosingParanthesis(css, index + 1, end)
-      rules.push(ruleNode(css, _start, index, _end))
+
+      rules.push(ruleNode(
+        css,
+        filterNodesForLocation(interpolations, _start, _end),
+        _start,
+        index,
+        _end
+      ))
 
       index = _start = _end + 1
     } else if (token === ':') {
       const _end = findToken(css, ';', index, end)
-      declarations.push(declarationNode(css, _start, index, _end))
+
+      declarations.push(declarationNode(
+        css,
+        filterNodesForLocation(interpolations, _start, _end),
+        _start,
+        index,
+        _end
+      ))
 
       index = _start = _end + 1
     } else {
@@ -80,8 +121,21 @@ export const blockNode = (css, start, end) => {
   }
 }
 
-const parse = css => {
-  return blockNode(css, 0, css.length - 1)
+// Takes an array of CSS strings and Babel AST Nodes of interpolations
+const parse = (cssArr, ...nodes) => {
+  const interpolations = []
+  let css = ''
+
+  for (let i = 0; i < cssArr.length; i++) {
+    css += cssArr[i]
+
+    const loc = css.length
+    const node = nodes[i]
+
+    interpolations.push(interpolationNode(node, loc))
+  }
+
+  return blockNode(css, interpolations, 0, css.length - 1)
 }
 
 export default parse

--- a/src/css/parser.js
+++ b/src/css/parser.js
@@ -13,16 +13,19 @@ export const interpolationNode = (babelNode, loc) => ({
 export const selectorNode = (css, interpolations, start, end) => ({
   type: 'SelectorLiteral',
   loc: [start, end],
-  value: css.slice(start, end).trim()
+  interpolations,
+  value: css.slice(start, end)
 })
 
 export const propertyNode = (css, interpolations, start, end) => {
-  const value = css.slice(start, end).trim()
+  const value = css.slice(start, end)
 
   if (value.includes(';')) {
     throw new Error(`Unexpected token! Properties cannot contain ';'.`)
-  } else if (/\s/g.test(value)) {
+  } else if (/\s/g.test(value.trim())) {
     throw new Error(`Unexpected token! Properties cannot contain whitespaces.`)
+  } else if (interpolations.length) {
+    throw new Error(`Unexpected interpolation! Properties cannot contain interpolations.`)
   }
 
   return {
@@ -35,7 +38,8 @@ export const propertyNode = (css, interpolations, start, end) => {
 export const valueNode = (css, interpolations, start, end) => ({
   type: 'ValueLiteral',
   loc: [start, end],
-  value: css.slice(start, end).trim()
+  interpolations,
+  value: css.slice(start, end)
 })
 
 // Parses a declaration of the form `property: value`

--- a/src/css/parser.js
+++ b/src/css/parser.js
@@ -129,7 +129,7 @@ const parse = (cssArr, ...nodes) => {
   for (let i = 0; i < cssArr.length; i++) {
     css += cssArr[i]
 
-    const loc = css.length
+    const loc = Math.max(0, css.length - 1)
     const node = nodes[i]
 
     interpolations.push(interpolationNode(node, loc))

--- a/src/css/unnest.js
+++ b/src/css/unnest.js
@@ -1,0 +1,63 @@
+import { prependSelector } from './utils/unnestUtils'
+
+const unnest = node => {
+  const rules = []
+
+  // Recursively call unnest rule and return block without them
+  const unnestBlock = (blockNode, selectorPath) => {
+    for (const rule of blockNode.rules) {
+      unnestRule(rule, selectorPath)
+    }
+
+    return Object.assign({}, blockNode, {
+      rules: []
+    })
+  }
+
+  // Unnest deep block and selector on rule
+  const unnestRule = (ruleNode, selectorPath) => {
+    const selector = (
+      selectorPath ?
+        prependSelector(ruleNode.selector, selectorPath) :
+        ruleNode.selector
+    )
+
+    const rule = Object.assign({}, ruleNode, {
+      selector
+    })
+
+    // Push first then unnest to preserve sorting
+    rules.push(rule)
+
+    // Unnest deep block and set it on new rule
+    const block = unnestBlock(ruleNode.block, selector.value)
+    rule.block = block
+  }
+
+  if (node.type === 'Rule') {
+    unnestRule(node)
+  } else if (node.type === 'Block') {
+    const rule = {
+      type: 'Rule',
+      loc: node.loc,
+      selector: {
+        type: 'SelectorLiteral',
+        loc: [0, 0],
+        interpolations: [],
+        value: '&'
+      }
+    }
+
+    // See above: Push first then unnest to preserve sorting
+    rules.push(rule)
+
+    // See above: Unnest deep block and set it on new rule
+    const block = unnestBlock(node)
+    rule.block = block
+  }
+
+  // Return resulting rules array
+  return rules
+}
+
+export default unnest

--- a/src/css/utils/parsingUtils.js
+++ b/src/css/utils/parsingUtils.js
@@ -1,0 +1,44 @@
+export const findToken = (css, needle, start, end) => {
+  let index = start
+
+  while (
+    css[index] !== needle &&
+    index <= end
+  ) {
+    index++
+  }
+
+  // Throw if there's no matching token
+  if (index > end) {
+    throw new Error(`Unexpected token! Unable to find matching '${needle}'.`)
+  }
+
+  return index
+}
+
+export const findClosingParanthesis = (css, start, end) => {
+  let level = 1
+  let index
+
+  for(
+    index = start;
+    level > 0 && index <= end;
+    index++
+  ) {
+    const token = css[index]
+
+    if (token === '{') {
+      level++
+    } else if (token === '}') {
+      level--
+    }
+  }
+
+  // Throw if there's no matching token
+  if (index >= end) {
+    throw new Error(`Unexpected token! Unable to find matching '}'.`)
+  }
+
+  return index
+}
+

--- a/src/css/utils/parsingUtils.js
+++ b/src/css/utils/parsingUtils.js
@@ -42,3 +42,15 @@ export const findClosingParanthesis = (css, start, end) => {
   return index
 }
 
+// Filters nodes for `loc` that falls in-between start and end
+export const filterNodesForLocation = (nodes, start, end) => nodes
+  .filter(({ loc }) => {
+    const nodeStart = Math.max(0, loc[0] - 1)
+    const nodeEnd = Math.max(0, loc[1] - 1)
+
+    return (
+      nodeStart >= start && nodeStart <= end &&
+      nodeEnd >= start && nodeEnd <= end
+    )
+  })
+

--- a/src/css/utils/parsingUtils.js
+++ b/src/css/utils/parsingUtils.js
@@ -44,13 +44,8 @@ export const findClosingParanthesis = (css, start, end) => {
 
 // Filters nodes for `loc` that falls in-between start and end
 export const filterNodesForLocation = (nodes, start, end) => nodes
-  .filter(({ loc }) => {
-    const nodeStart = Math.max(0, loc[0] - 1)
-    const nodeEnd = Math.max(0, loc[1] - 1)
-
-    return (
-      nodeStart >= start && nodeStart <= end &&
-      nodeEnd >= start && nodeEnd <= end
-    )
-  })
+  .filter(({ loc }) => (
+    loc[0] >= start && loc[0] <= end &&
+    loc[1] >= start && loc[1] <= end
+  ))
 

--- a/src/css/utils/unnestUtils.js
+++ b/src/css/utils/unnestUtils.js
@@ -1,0 +1,16 @@
+const shiftInterpolations = (interpolations, shift) => interpolations
+  .map(interpolation => Object.assign({}, interpolation, {
+    loc: [
+      interpolation.loc[0] + shift,
+      interpolation.loc[1] + shift,
+    ]
+  }))
+
+export const prependSelector = (selectorNode, prepend) => Object.assign(
+  {},
+  selectorNode,
+  {
+    interpolations: shiftInterpolations(selectorNode.interpolations, prepend.length + 1),
+    value: `${prepend} ${selectorNode.value}`
+  }
+)

--- a/test/css/parser/__snapshots__/declarationsOnly.test.js.snap
+++ b/test/css/parser/__snapshots__/declarationsOnly.test.js.snap
@@ -1,0 +1,58 @@
+exports[`parse declarations only parses normal declarations 1`] = `
+Object {
+  "declarations": Array [
+    Object {
+      "loc": Array [
+        0,
+        17,
+      ],
+      "property": Object {
+        "loc": Array [
+          0,
+          12,
+        ],
+        "type": "PropertyLiteral",
+        "value": "color",
+      },
+      "type": "Declaration",
+      "value": Object {
+        "loc": Array [
+          13,
+          17,
+        ],
+        "type": "ValueLiteral",
+        "value": "red",
+      },
+    },
+    Object {
+      "loc": Array [
+        18,
+        43,
+      ],
+      "property": Object {
+        "loc": Array [
+          18,
+          35,
+        ],
+        "type": "PropertyLiteral",
+        "value": "text-align",
+      },
+      "type": "Declaration",
+      "value": Object {
+        "loc": Array [
+          36,
+          43,
+        ],
+        "type": "ValueLiteral",
+        "value": "center",
+      },
+    },
+  ],
+  "loc": Array [
+    0,
+    48,
+  ],
+  "rules": Array [],
+  "type": "Block",
+}
+`;

--- a/test/css/parser/__snapshots__/declarationsOnly.test.js.snap
+++ b/test/css/parser/__snapshots__/declarationsOnly.test.js.snap
@@ -12,16 +12,18 @@ Object {
           12,
         ],
         "type": "PropertyLiteral",
-        "value": "color",
+        "value": "
+      color",
       },
       "type": "Declaration",
       "value": Object {
+        "interpolations": Array [],
         "loc": Array [
           13,
           17,
         ],
         "type": "ValueLiteral",
-        "value": "red",
+        "value": " red",
       },
     },
     Object {
@@ -35,16 +37,18 @@ Object {
           35,
         ],
         "type": "PropertyLiteral",
-        "value": "text-align",
+        "value": "
+      text-align",
       },
       "type": "Declaration",
       "value": Object {
+        "interpolations": Array [],
         "loc": Array [
           36,
           43,
         ],
         "type": "ValueLiteral",
-        "value": "center",
+        "value": " center",
       },
     },
   ],

--- a/test/css/parser/__snapshots__/rulesOnly.test.js.snap
+++ b/test/css/parser/__snapshots__/rulesOnly.test.js.snap
@@ -29,12 +29,14 @@ Object {
               35,
             ],
             "selector": Object {
+              "interpolations": Array [],
               "loc": Array [
                 16,
                 32,
               ],
               "type": "SelectorLiteral",
-              "value": ".innerA",
+              "value": "
+        .innerA",
             },
             "type": "Rule",
           },
@@ -46,12 +48,14 @@ Object {
         43,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           0,
           14,
         ],
         "type": "SelectorLiteral",
-        "value": ".outerA",
+        "value": "
+      .outerA",
       },
       "type": "Rule",
     },
@@ -78,12 +82,14 @@ Object {
               79,
             ],
             "selector": Object {
+              "interpolations": Array [],
               "loc": Array [
                 60,
                 76,
               ],
               "type": "SelectorLiteral",
-              "value": ".innerB",
+              "value": "
+        .innerB",
             },
             "type": "Rule",
           },
@@ -95,12 +101,14 @@ Object {
         87,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           44,
           58,
         ],
         "type": "SelectorLiteral",
-        "value": ".outerB",
+        "value": "
+      .outerB",
       },
       "type": "Rule",
     },
@@ -132,12 +140,14 @@ Object {
         17,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           0,
           14,
         ],
         "type": "SelectorLiteral",
-        "value": ".classA",
+        "value": "
+      .classA",
       },
       "type": "Rule",
     },
@@ -156,12 +166,13 @@ Object {
         34,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           18,
           31,
         ],
         "type": "SelectorLiteral",
-        "value": ".classB",
+        "value": "      .classB",
       },
       "type": "Rule",
     },
@@ -201,12 +212,14 @@ Object {
               33,
             ],
             "selector": Object {
+              "interpolations": Array [],
               "loc": Array [
                 15,
                 30,
               ],
               "type": "SelectorLiteral",
-              "value": ".inner",
+              "value": "
+        .inner",
             },
             "type": "Rule",
           },
@@ -218,12 +231,14 @@ Object {
         41,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           0,
           13,
         ],
         "type": "SelectorLiteral",
-        "value": ".outer",
+        "value": "
+      .outer",
       },
       "type": "Rule",
     },
@@ -255,12 +270,14 @@ Object {
         23,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           0,
           13,
         ],
         "type": "SelectorLiteral",
-        "value": ".class",
+        "value": "
+      .class",
       },
       "type": "Rule",
     },
@@ -291,16 +308,18 @@ Object {
                 34,
               ],
               "type": "PropertyLiteral",
-              "value": "text-align",
+              "value": "
+        text-align",
             },
             "type": "Declaration",
             "value": Object {
+              "interpolations": Array [],
               "loc": Array [
                 35,
                 42,
               ],
               "type": "ValueLiteral",
-              "value": "center",
+              "value": " center",
             },
           },
         ],
@@ -316,12 +335,14 @@ Object {
         51,
       ],
       "selector": Object {
+        "interpolations": Array [],
         "loc": Array [
           0,
           13,
         ],
         "type": "SelectorLiteral",
-        "value": ".class",
+        "value": "
+      .class",
       },
       "type": "Rule",
     },

--- a/test/css/parser/__snapshots__/rulesOnly.test.js.snap
+++ b/test/css/parser/__snapshots__/rulesOnly.test.js.snap
@@ -1,0 +1,331 @@
+exports[`parse rules only parses multiple nested rules 1`] = `
+Object {
+  "declarations": Array [],
+  "loc": Array [
+    0,
+    91,
+  ],
+  "rules": Array [
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          16,
+          42,
+        ],
+        "rules": Array [
+          Object {
+            "block": Object {
+              "declarations": Array [],
+              "loc": Array [
+                34,
+                34,
+              ],
+              "rules": Array [],
+              "type": "Block",
+            },
+            "loc": Array [
+              16,
+              35,
+            ],
+            "selector": Object {
+              "loc": Array [
+                16,
+                32,
+              ],
+              "type": "SelectorLiteral",
+              "value": ".innerA",
+            },
+            "type": "Rule",
+          },
+        ],
+        "type": "Block",
+      },
+      "loc": Array [
+        0,
+        43,
+      ],
+      "selector": Object {
+        "loc": Array [
+          0,
+          14,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".outerA",
+      },
+      "type": "Rule",
+    },
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          60,
+          86,
+        ],
+        "rules": Array [
+          Object {
+            "block": Object {
+              "declarations": Array [],
+              "loc": Array [
+                78,
+                78,
+              ],
+              "rules": Array [],
+              "type": "Block",
+            },
+            "loc": Array [
+              60,
+              79,
+            ],
+            "selector": Object {
+              "loc": Array [
+                60,
+                76,
+              ],
+              "type": "SelectorLiteral",
+              "value": ".innerB",
+            },
+            "type": "Rule",
+          },
+        ],
+        "type": "Block",
+      },
+      "loc": Array [
+        44,
+        87,
+      ],
+      "selector": Object {
+        "loc": Array [
+          44,
+          58,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".outerB",
+      },
+      "type": "Rule",
+    },
+  ],
+  "type": "Block",
+}
+`;
+
+exports[`parse rules only parses multiple rules 1`] = `
+Object {
+  "declarations": Array [],
+  "loc": Array [
+    0,
+    38,
+  ],
+  "rules": Array [
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          16,
+          16,
+        ],
+        "rules": Array [],
+        "type": "Block",
+      },
+      "loc": Array [
+        0,
+        17,
+      ],
+      "selector": Object {
+        "loc": Array [
+          0,
+          14,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".classA",
+      },
+      "type": "Rule",
+    },
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          33,
+          33,
+        ],
+        "rules": Array [],
+        "type": "Block",
+      },
+      "loc": Array [
+        18,
+        34,
+      ],
+      "selector": Object {
+        "loc": Array [
+          18,
+          31,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".classB",
+      },
+      "type": "Rule",
+    },
+  ],
+  "type": "Block",
+}
+`;
+
+exports[`parse rules only parses nested rules 1`] = `
+Object {
+  "declarations": Array [],
+  "loc": Array [
+    0,
+    45,
+  ],
+  "rules": Array [
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          15,
+          40,
+        ],
+        "rules": Array [
+          Object {
+            "block": Object {
+              "declarations": Array [],
+              "loc": Array [
+                32,
+                32,
+              ],
+              "rules": Array [],
+              "type": "Block",
+            },
+            "loc": Array [
+              15,
+              33,
+            ],
+            "selector": Object {
+              "loc": Array [
+                15,
+                30,
+              ],
+              "type": "SelectorLiteral",
+              "value": ".inner",
+            },
+            "type": "Rule",
+          },
+        ],
+        "type": "Block",
+      },
+      "loc": Array [
+        0,
+        41,
+      ],
+      "selector": Object {
+        "loc": Array [
+          0,
+          13,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".outer",
+      },
+      "type": "Rule",
+    },
+  ],
+  "type": "Block",
+}
+`;
+
+exports[`parse rules only parses normal rules 1`] = `
+Object {
+  "declarations": Array [],
+  "loc": Array [
+    0,
+    27,
+  ],
+  "rules": Array [
+    Object {
+      "block": Object {
+        "declarations": Array [],
+        "loc": Array [
+          15,
+          22,
+        ],
+        "rules": Array [],
+        "type": "Block",
+      },
+      "loc": Array [
+        0,
+        23,
+      ],
+      "selector": Object {
+        "loc": Array [
+          0,
+          13,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".class",
+      },
+      "type": "Rule",
+    },
+  ],
+  "type": "Block",
+}
+`;
+
+exports[`parse rules only parses rules containing declarations 1`] = `
+Object {
+  "declarations": Array [],
+  "loc": Array [
+    0,
+    55,
+  ],
+  "rules": Array [
+    Object {
+      "block": Object {
+        "declarations": Array [
+          Object {
+            "loc": Array [
+              15,
+              42,
+            ],
+            "property": Object {
+              "loc": Array [
+                15,
+                34,
+              ],
+              "type": "PropertyLiteral",
+              "value": "text-align",
+            },
+            "type": "Declaration",
+            "value": Object {
+              "loc": Array [
+                35,
+                42,
+              ],
+              "type": "ValueLiteral",
+              "value": "center",
+            },
+          },
+        ],
+        "loc": Array [
+          15,
+          50,
+        ],
+        "rules": Array [],
+        "type": "Block",
+      },
+      "loc": Array [
+        0,
+        51,
+      ],
+      "selector": Object {
+        "loc": Array [
+          0,
+          13,
+        ],
+        "type": "SelectorLiteral",
+        "value": ".class",
+      },
+      "type": "Rule",
+    },
+  ],
+  "type": "Block",
+}
+`;

--- a/test/css/parser/declarationsOnly.test.js
+++ b/test/css/parser/declarationsOnly.test.js
@@ -1,0 +1,31 @@
+import parse from '../../../src/css/parser';
+
+describe('parse declarations only', () => {
+  it('parses normal declarations', () => {
+    expect(parse(`
+      color: red;
+      text-align: center;
+    `)).toMatchSnapshot();
+  });
+
+  it('throws if semicolon is missing', () => {
+    expect(() => parse(`
+      color: red;
+      text-align: center
+    `)).toThrow();
+  });
+
+  it('throws if colon is missing', () => {
+    expect(() => parse(`
+      color red;
+      text-align: center;
+    `)).toThrow();
+  });
+
+  it('throws if property contains a whitespace', () => {
+    expect(() => parse(`
+      color is: red;
+      text-align: center;
+    `)).toThrow();
+  });
+});

--- a/test/css/parser/declarationsOnly.test.js
+++ b/test/css/parser/declarationsOnly.test.js
@@ -2,30 +2,30 @@ import parse from '../../../src/css/parser';
 
 describe('parse declarations only', () => {
   it('parses normal declarations', () => {
-    expect(parse(`
+    expect(parse`
       color: red;
       text-align: center;
-    `)).toMatchSnapshot();
+    `).toMatchSnapshot();
   });
 
   it('throws if semicolon is missing', () => {
-    expect(() => parse(`
+    expect(() => parse`
       color: red;
       text-align: center
-    `)).toThrow();
+    `).toThrow();
   });
 
   it('throws if colon is missing', () => {
-    expect(() => parse(`
+    expect(() => parse`
       color red;
       text-align: center;
-    `)).toThrow();
+    `).toThrow();
   });
 
   it('throws if property contains a whitespace', () => {
-    expect(() => parse(`
+    expect(() => parse`
       color is: red;
       text-align: center;
-    `)).toThrow();
+    `).toThrow();
   });
 });

--- a/test/css/parser/declarationsOnly.test.js
+++ b/test/css/parser/declarationsOnly.test.js
@@ -12,6 +12,7 @@ describe('parse declarations only', () => {
     expect(() => parse`
       color: red;
       text-align: center
+      font-family: "Operator Mono";
     `).toThrow();
   });
 

--- a/test/css/parser/rulesOnly.test.js
+++ b/test/css/parser/rulesOnly.test.js
@@ -8,7 +8,7 @@ describe('parse rules only', () => {
     `
 
     expect(ast).toMatchSnapshot();
-    expect(ast.rules[0].selector.value).toBe('.class');
+    expect(ast.rules[0].selector.value.trim()).toBe('.class');
   });
 
   it('parses multiple rules', () => {
@@ -18,8 +18,8 @@ describe('parse rules only', () => {
     `
 
     expect(ast).toMatchSnapshot();
-    expect(ast.rules[0].selector.value).toBe('.classA');
-    expect(ast.rules[1].selector.value).toBe('.classB');
+    expect(ast.rules[0].selector.value.trim()).toBe('.classA');
+    expect(ast.rules[1].selector.value.trim()).toBe('.classB');
   });
 
   it('parses nested rules', () => {
@@ -30,7 +30,7 @@ describe('parse rules only', () => {
     `
 
     expect(ast).toMatchSnapshot();
-    expect(ast.rules[0].selector.value).toBe('.outer');
+    expect(ast.rules[0].selector.value.trim()).toBe('.outer');
   });
 
   it('parses multiple nested rules', () => {
@@ -45,8 +45,8 @@ describe('parse rules only', () => {
     `
 
     expect(ast).toMatchSnapshot();
-    expect(ast.rules[0].selector.value).toBe('.outerA');
-    expect(ast.rules[1].selector.value).toBe('.outerB');
+    expect(ast.rules[0].selector.value.trim()).toBe('.outerA');
+    expect(ast.rules[1].selector.value.trim()).toBe('.outerB');
   });
 
   it('parses rules containing declarations', () => {
@@ -57,8 +57,8 @@ describe('parse rules only', () => {
     `
 
     expect(ast).toMatchSnapshot();
-    expect(ast.rules[0].block.declarations[0].property.value).toBe('text-align');
-    expect(ast.rules[0].block.declarations[0].value.value).toBe('center');
+    expect(ast.rules[0].block.declarations[0].property.value.trim()).toBe('text-align');
+    expect(ast.rules[0].block.declarations[0].value.value.trim()).toBe('center');
   });
 
   it('throws if closing paranthesis is missing', () => {

--- a/test/css/parser/rulesOnly.test.js
+++ b/test/css/parser/rulesOnly.test.js
@@ -1,0 +1,78 @@
+import parse from '../../../src/css/parser';
+
+describe('parse rules only', () => {
+  it('parses normal rules', () => {
+    const ast = parse(`
+      .class {
+      }
+    `)
+
+    expect(ast).toMatchSnapshot();
+    expect(ast.rules[0].selector.value).toBe('.class');
+  });
+
+  it('parses multiple rules', () => {
+    const ast = parse(`
+      .classA {}
+      .classB {}
+    `)
+
+    expect(ast).toMatchSnapshot();
+    expect(ast.rules[0].selector.value).toBe('.classA');
+    expect(ast.rules[1].selector.value).toBe('.classB');
+  });
+
+  it('parses nested rules', () => {
+    const ast = parse(`
+      .outer {
+        .inner {}
+      }
+    `)
+
+    expect(ast).toMatchSnapshot();
+    expect(ast.rules[0].selector.value).toBe('.outer');
+  });
+
+  it('parses multiple nested rules', () => {
+    const ast = parse(`
+      .outerA {
+        .innerA {}
+      }
+
+      .outerB {
+        .innerB {}
+      }
+    `)
+
+    expect(ast).toMatchSnapshot();
+    expect(ast.rules[0].selector.value).toBe('.outerA');
+    expect(ast.rules[1].selector.value).toBe('.outerB');
+  });
+
+  it('parses rules containing declarations', () => {
+    const ast = parse(`
+      .class {
+        text-align: center;
+      }
+    `)
+
+    expect(ast).toMatchSnapshot();
+    expect(ast.rules[0].block.declarations[0].property.value).toBe('text-align');
+    expect(ast.rules[0].block.declarations[0].value.value).toBe('center');
+  });
+
+  it('throws if closing paranthesis is missing', () => {
+    expect(() => parse(`
+      .class {
+        text-align: center;
+    `)).toThrow()
+  });
+
+  it('throws if closing paranthesis is missing', () => {
+    expect(() => parse(`
+      .classA {
+        text-align: center;
+        .classB {}
+    `)).toThrow()
+  });
+});

--- a/test/css/parser/rulesOnly.test.js
+++ b/test/css/parser/rulesOnly.test.js
@@ -2,20 +2,20 @@ import parse from '../../../src/css/parser';
 
 describe('parse rules only', () => {
   it('parses normal rules', () => {
-    const ast = parse(`
+    const ast = parse`
       .class {
       }
-    `)
+    `
 
     expect(ast).toMatchSnapshot();
     expect(ast.rules[0].selector.value).toBe('.class');
   });
 
   it('parses multiple rules', () => {
-    const ast = parse(`
+    const ast = parse`
       .classA {}
       .classB {}
-    `)
+    `
 
     expect(ast).toMatchSnapshot();
     expect(ast.rules[0].selector.value).toBe('.classA');
@@ -23,18 +23,18 @@ describe('parse rules only', () => {
   });
 
   it('parses nested rules', () => {
-    const ast = parse(`
+    const ast = parse`
       .outer {
         .inner {}
       }
-    `)
+    `
 
     expect(ast).toMatchSnapshot();
     expect(ast.rules[0].selector.value).toBe('.outer');
   });
 
   it('parses multiple nested rules', () => {
-    const ast = parse(`
+    const ast = parse`
       .outerA {
         .innerA {}
       }
@@ -42,7 +42,7 @@ describe('parse rules only', () => {
       .outerB {
         .innerB {}
       }
-    `)
+    `
 
     expect(ast).toMatchSnapshot();
     expect(ast.rules[0].selector.value).toBe('.outerA');
@@ -50,11 +50,11 @@ describe('parse rules only', () => {
   });
 
   it('parses rules containing declarations', () => {
-    const ast = parse(`
+    const ast = parse`
       .class {
         text-align: center;
       }
-    `)
+    `
 
     expect(ast).toMatchSnapshot();
     expect(ast.rules[0].block.declarations[0].property.value).toBe('text-align');
@@ -62,10 +62,10 @@ describe('parse rules only', () => {
   });
 
   it('throws if closing paranthesis is missing', () => {
-    expect(() => parse(`
+    expect(() => parse`
       .class {
         text-align: center;
-    `)).toThrow()
+    `).toThrow()
   });
 
   it('throws if closing paranthesis is missing', () => {

--- a/test/css/unnest/__snapshots__/unnest.test.js.snap
+++ b/test/css/unnest/__snapshots__/unnest.test.js.snap
@@ -1,0 +1,267 @@
+exports[`unnest should work on nested rules 1`] = `
+Array [
+  Object {
+    "block": Object {
+      "declarations": Array [
+        Object {
+          "loc": Array [
+            0,
+            17,
+          ],
+          "property": Object {
+            "loc": Array [
+              0,
+              12,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+      color",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              13,
+              17,
+            ],
+            "type": "ValueLiteral",
+            "value": " red",
+          },
+        },
+        Object {
+          "loc": Array [
+            18,
+            41,
+          ],
+          "property": Object {
+            "loc": Array [
+              18,
+              35,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+      background",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              36,
+              41,
+            ],
+            "type": "ValueLiteral",
+            "value": " blue",
+          },
+        },
+      ],
+      "loc": Array [
+        0,
+        93,
+      ],
+      "rules": Array [],
+      "type": "Block",
+    },
+    "loc": Array [
+      0,
+      93,
+    ],
+    "selector": Object {
+      "interpolations": Array [],
+      "loc": Array [
+        0,
+        0,
+      ],
+      "type": "SelectorLiteral",
+      "value": "&",
+    },
+    "type": "Rule",
+  },
+  Object {
+    "block": Object {
+      "declarations": Array [
+        Object {
+          "loc": Array [
+            59,
+            80,
+          ],
+          "property": Object {
+            "loc": Array [
+              59,
+              73,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+        color",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              74,
+              80,
+            ],
+            "type": "ValueLiteral",
+            "value": " green",
+          },
+        },
+      ],
+      "loc": Array [
+        59,
+        88,
+      ],
+      "rules": Array [],
+      "type": "Block",
+    },
+    "loc": Array [
+      42,
+      89,
+    ],
+    "selector": Object {
+      "interpolations": Array [],
+      "loc": Array [
+        42,
+        57,
+      ],
+      "type": "SelectorLiteral",
+      "value": "
+
+      & > div",
+    },
+    "type": "Rule",
+  },
+]
+`;
+
+exports[`unnest should work on nested rules containing pseudo selectors 1`] = `
+Array [
+  Object {
+    "block": Object {
+      "declarations": Array [
+        Object {
+          "loc": Array [
+            0,
+            17,
+          ],
+          "property": Object {
+            "loc": Array [
+              0,
+              12,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+      color",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              13,
+              17,
+            ],
+            "type": "ValueLiteral",
+            "value": " red",
+          },
+        },
+        Object {
+          "loc": Array [
+            18,
+            41,
+          ],
+          "property": Object {
+            "loc": Array [
+              18,
+              35,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+      background",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              36,
+              41,
+            ],
+            "type": "ValueLiteral",
+            "value": " blue",
+          },
+        },
+      ],
+      "loc": Array [
+        0,
+        93,
+      ],
+      "rules": Array [],
+      "type": "Block",
+    },
+    "loc": Array [
+      0,
+      93,
+    ],
+    "selector": Object {
+      "interpolations": Array [],
+      "loc": Array [
+        0,
+        0,
+      ],
+      "type": "SelectorLiteral",
+      "value": "&",
+    },
+    "type": "Rule",
+  },
+  Object {
+    "block": Object {
+      "declarations": Array [
+        Object {
+          "loc": Array [
+            59,
+            80,
+          ],
+          "property": Object {
+            "loc": Array [
+              59,
+              73,
+            ],
+            "type": "PropertyLiteral",
+            "value": "
+        color",
+          },
+          "type": "Declaration",
+          "value": Object {
+            "interpolations": Array [],
+            "loc": Array [
+              74,
+              80,
+            ],
+            "type": "ValueLiteral",
+            "value": " green",
+          },
+        },
+      ],
+      "loc": Array [
+        59,
+        88,
+      ],
+      "rules": Array [],
+      "type": "Block",
+    },
+    "loc": Array [
+      42,
+      89,
+    ],
+    "selector": Object {
+      "interpolations": Array [],
+      "loc": Array [
+        42,
+        57,
+      ],
+      "type": "SelectorLiteral",
+      "value": "
+
+      &:hover",
+    },
+    "type": "Rule",
+  },
+]
+`;

--- a/test/css/unnest/unnest.test.js
+++ b/test/css/unnest/unnest.test.js
@@ -1,0 +1,32 @@
+import unnest from '../../../src/css/unnest';
+import parse from '../../../src/css/parser';
+
+describe('unnest', () => {
+  it('should work on nested rules', () => {
+    const ast = parse`
+      color: red;
+      background: blue;
+
+      & > div {
+        color: green;
+      }
+    `
+
+    const unnested = unnest(ast)
+    expect(unnested).toMatchSnapshot()
+  })
+
+  it('should work on nested rules containing pseudo selectors', () => {
+    const ast = parse`
+      color: red;
+      background: blue;
+
+      &:hover {
+        color: green;
+      }
+    `
+
+    const unnested = unnest(ast)
+    expect(unnested).toMatchSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,6 +322,14 @@ babel-jest@^17.0.2:
     babel-plugin-istanbul "^2.0.0"
     babel-preset-jest "^17.0.2"
 
+babel-jest@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-18.0.0.tgz#17ebba8cb3285c906d859e8707e4e79795fb65e3"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^3.0.0"
+    babel-preset-jest "^18.0.0"
+
 babel-messages@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.8.0.tgz#bf504736ca967e6d65ef0adb5a2a5f947c8e0eb9"
@@ -343,9 +351,22 @@ babel-plugin-istanbul@^2.0.0:
     object-assign "^4.1.0"
     test-exclude "^2.1.1"
 
+babel-plugin-istanbul@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-3.1.2.tgz#11d5abde18425ec24b5d648c7e0b5d25cd354a22"
+  dependencies:
+    find-up "^1.1.2"
+    istanbul-lib-instrument "^1.4.2"
+    object-assign "^4.1.0"
+    test-exclude "^3.3.0"
+
 babel-plugin-jest-hoist@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-17.0.2.tgz#213488ce825990acd4c30f887dca09fffeb45235"
+
+babel-plugin-jest-hoist@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-18.0.0.tgz#4150e70ecab560e6e7344adc849498072d34e12a"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -605,6 +626,12 @@ babel-preset-jest@^17.0.2:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-17.0.2.tgz#141e935debe164aaa0364c220d31ccb2176493b2"
   dependencies:
     babel-plugin-jest-hoist "^17.0.2"
+
+babel-preset-jest@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-18.0.0.tgz#84faf8ca3ec65aba7d5e3f59bbaed935ab24049e"
+  dependencies:
+    babel-plugin-jest-hoist "^18.0.0"
 
 babel-register@^6.18.0:
   version "6.18.0"
@@ -1443,6 +1470,18 @@ istanbul-lib-hook@^1.0.0-alpha:
 istanbul-lib-instrument@^1.0.0-alpha, istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz#19f0a973397454989b98330333063a5b56df0e58"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.13.0"
+    istanbul-lib-coverage "^1.0.0"
+    semver "^5.3.0"
+
+istanbul-lib-instrument@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz#0e2fdfac93c1dabf2e31578637dc78a19089f43e"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
@@ -2551,6 +2590,16 @@ tar@~2.2.1:
 test-exclude@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-2.1.3.tgz#a8d8968e1da83266f9864f2852c55e220f06434a"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^2.3.11"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+test-exclude@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-3.3.0.tgz#7a17ca1239988c98367b0621456dbb7d4bc38977"
   dependencies:
     arrify "^1.0.1"
     micromatch "^2.3.11"


### PR DESCRIPTION
- [x] Minimal CSS parser that outputs an AST
- [x] Un-nesting transformer that flattens the AST
- [ ] Determine the format of the result we want to generate for `styled-components` to consume
- [ ] Add `preprocessTemplateLiterals` visitor (Very easy; can be seen in the `postcss-preprocessing` branch)
- [ ] Determine how preprocessed CSS in interpolations should work
- [ ] Write ludicrously high amount of unit tests