### PR TITLE
Disable SSR option by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # `babel-plugin-styled-components`
 
-Babel plugin for `styled-components`. This is **only necessary if you're server-side rendering**, you can use `styled-components` perfectly fine without this Babel plugin. (it does give you a nicer debugging experience though)
+This plugin adds support for server-side rendering, for minification of styles and gives you a nicer debugging experience when using `styled-components`.
+
+**⚠️ This plugin is only necessary if you're server-side rendering, you can use `styled-components` perfectly fine without it! ⚠️**
 
 ## Usage
 
@@ -20,9 +22,27 @@ Then in your babel configuration (probably `.babelrc`):
 
 ## Features
 
+- [Server-side rendering](#server-side-rendering)
 - [Better debugging](#better-debugging)
 - [Minification](#minification)
-- [Server-side rendering](#server-side-rendering)
+
+### Server-side rendering
+
+**This option is turned off by default**
+
+By adding a unique identifier to every styled component this plugin avoids checksum mismatches due to different class generation on the client and on the server. If you do not use this plugin and try to server-side render `styled-components` React will complain.
+
+If you want server-side rendering support you can enable it with the `ssr` option:
+
+```JSON
+{
+  "plugins": [
+    ["styled-components", {
+      "ssr": true
+    }]
+  ]
+}
+```
 
 ### Better debugging
 
@@ -85,22 +105,6 @@ You can disable minification with the `minify` option:
 ```
 
 We also transpile `styled-components` tagged template literals down to a smaller representation than what Babel normally does, because `styled-components` template literals don't need to be 100% spec compliant. (see [`minification.md`](minification.md) for more information about that) You can use the `transpileTemplateLiterals` option to turn this feature off.
-
-### Server-side rendering
-
-By adding a unique identifier to every styled component this plugin avoids checksum mismatches due to different class generation on the client and on the server. If you do not use this plugin and try to server-side render `styled-components` React will complain.
-
-If you don't need server-side rendering, you can disable it with the `ssr` option:
-
-```JSON
-{
-  "plugins": [
-    ["styled-components", {
-      "ssr": false
-    }]
-  ]
-}
-```
 
 ## License
 

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -3,7 +3,7 @@ function getOption({ opts }, name, defaultValue = true) {
 }
 
 export const useDisplayName = (state) => getOption(state, 'displayName')
-export const useSSR = (state) =>  getOption(state, 'ssr')
+export const useSSR = (state) =>  getOption(state, 'ssr', false)
 export const useFileName = (state) =>getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL

--- a/test/fixtures/02-add-identifier/.babelrc
+++ b/test/fixtures/02-add-identifier/.babelrc
@@ -4,7 +4,7 @@
       "displayName": false,
       "fileName": false,
       "transpileTemplateLiterals": false,
-      "preprocess": false
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/02-add-identifier/.babelrc.orig
+++ b/test/fixtures/02-add-identifier/.babelrc.orig
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "displayName": false,
+      "fileName": false,
+<<<<<<< HEAD
+      "transpileTemplateLiterals": false,
+      "preprocess": false
+=======
+      "ssr": true,
+      "transpileTemplateLiterals": false
+>>>>>>> Disable the SSR option by default
+    }]
+  ]
+}

--- a/test/fixtures/03-add-identifier-and-display-name/.babelrc
+++ b/test/fixtures/03-add-identifier-and-display-name/.babelrc
@@ -3,7 +3,7 @@
     ["../../../src", {
       "fileName": false,
       "transpileTemplateLiterals": false,
-      "preprocess": false
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/03-add-identifier-and-display-name/.babelrc.orig
+++ b/test/fixtures/03-add-identifier-and-display-name/.babelrc.orig
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "fileName": false,
+<<<<<<< HEAD
+      "transpileTemplateLiterals": false,
+      "preprocess": false
+=======
+      "ssr": true,
+      "transpileTemplateLiterals": false
+>>>>>>> Disable the SSR option by default
+    }]
+  ]
+}

--- a/test/fixtures/04-track-the-imported-variable/.babelrc
+++ b/test/fixtures/04-track-the-imported-variable/.babelrc
@@ -3,7 +3,7 @@
     ["../../../src", {
       "fileName": false,
       "transpileTemplateLiterals": false,
-      "preprocess": false
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/04-track-the-imported-variable/.babelrc.orig
+++ b/test/fixtures/04-track-the-imported-variable/.babelrc.orig
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "fileName": false,
+<<<<<<< HEAD
+      "transpileTemplateLiterals": false,
+      "preprocess": false
+=======
+      "ssr": true,
+      "transpileTemplateLiterals": false
+>>>>>>> Disable the SSR option by default
+    }]
+  ]
+}

--- a/test/fixtures/05-use-file-name/.babelrc
+++ b/test/fixtures/05-use-file-name/.babelrc
@@ -2,7 +2,7 @@
   "plugins": [
     ["../../../src", {
       "transpileTemplateLiterals": false,
-      "preprocess": false
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/05-use-file-name/.babelrc.orig
+++ b/test/fixtures/05-use-file-name/.babelrc.orig
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "transpileTemplateLiterals": false,
+<<<<<<< HEAD
+      "preprocess": false
+=======
+      "ssr": true,
+>>>>>>> Disable the SSR option by default
+    }]
+  ]
+}

--- a/test/fixtures/06-work-with-hoisted-default-as-import/.babelrc
+++ b/test/fixtures/06-work-with-hoisted-default-as-import/.babelrc
@@ -2,7 +2,7 @@
   "plugins": [
     ["../../../src", {
       "transpileTemplateLiterals": false,
-      "preprocess": false
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/06-work-with-hoisted-default-as-import/.babelrc.orig
+++ b/test/fixtures/06-work-with-hoisted-default-as-import/.babelrc.orig
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "transpileTemplateLiterals": false,
+<<<<<<< HEAD
+      "preprocess": false
+=======
+      "ssr": true,
+>>>>>>> Disable the SSR option by default
+    }]
+  ]
+}

--- a/test/fixtures/14-preprocess-css/.babelrc
+++ b/test/fixtures/14-preprocess-css/.babelrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["../../../src", {
-      "preprocess": true
+      "preprocess": true,
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/15-preprocess-keyframes/.babelrc
+++ b/test/fixtures/15-preprocess-keyframes/.babelrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["../../../src", {
-      "preprocess": true
+      "preprocess": true,
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/16-preprocess-import/.babelrc
+++ b/test/fixtures/16-preprocess-import/.babelrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["../../../src", {
-      "preprocess": false
+      "preprocess": false,
+      "ssr": true
     }]
   ]
 }

--- a/test/fixtures/17-no-preprocess-import/.babelrc
+++ b/test/fixtures/17-no-preprocess-import/.babelrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["../../../src", {
-      "preprocess": true
+      "preprocess": true,
+      "ssr": true
     }]
   ]
 }


### PR DESCRIPTION
Given our amazing ability to improve the debugging experience and to minify the styles, a lot of people who aren't server-side rendering will want to use this plugin, so I think it makes sense to disable SSR by default.