### PR TITLE
Add 'module' option to use `no-parser.js` as an ES module

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ You can enable preprocessing with the `preprocess` option:
   ]
 }
 ```
-
-You can use the `no-parser.js` entry as an ES module by enabling the `module` option:
+If you use Rollup or webpack v2 you can take advantage of tree-shaking by setting the `module` option to true:
 
 ```JSON
 {

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ You can enable preprocessing with the `preprocess` option:
 }
 ```
 
+You can use the `no-parser.js` entry as an ES module by enabling the `module` option:
+
+```JSON
+{
+  "plugins": [
+    ["styled-components", {
+      "preprocess": true,
+      "module": true
+    }]
+  ]
+}
+```
+
 ### Minification
 
 This plugin minifies your styles in the tagged template literals, giving you big bundle size savings. (note that you will not see the effect of minification in generated `<style>` tags, it solely affects the style strings inside your JS bundle)

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -7,4 +7,5 @@ export const useSSR = (state) =>  getOption(state, 'ssr', false)
 export const useFileName = (state) =>getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL
+export const useESModule = (state) => getOption(state, 'module', false) // EXPERIMENTAL
 export const useTranspileTemplateLiterals = (state) => getOption(state, 'transpileTemplateLiterals')

--- a/src/visitors/noParserImport.js
+++ b/src/visitors/noParserImport.js
@@ -1,16 +1,18 @@
 import * as t from 'babel-types'
-import { useCSSPreprocessor } from '../utils/options'
+import { useCSSPreprocessor, useESModule } from '../utils/options'
 
 export const noParserImportDeclaration = (path, state) => {
+  const noParserPath = useESModule(state) ? 'dist/no-parser.es' : 'no-parser'
   if (
     useCSSPreprocessor(state) &&
     path.node.source.value === 'styled-components'
   ) {
-    path.node.source = t.stringLiteral('styled-components/no-parser')
+    path.node.source = t.stringLiteral(`styled-components/${noParserPath}`)
   }
 }
 
 export const noParserRequireCallExpression = (path, state) => {
+  const noParserPath = useESModule(state) ? 'dist/no-parser.es' : 'no-parser'
   if (
     useCSSPreprocessor(state) &&
     path.node.callee.name === 'require' &&
@@ -19,6 +21,6 @@ export const noParserRequireCallExpression = (path, state) => {
     t.isStringLiteral(path.node.arguments[0]) &&
     path.node.arguments[0].value === 'styled-components'
   ) {
-    path.node.arguments = [t.stringLiteral('styled-components/no-parser')]
+    path.node.arguments = [t.stringLiteral(`styled-components/${noParserPath}`)]
   }
 }

--- a/test/fixtures/18-preprocess-import-as-module/.babelrc
+++ b/test/fixtures/18-preprocess-import-as-module/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "preprocess": true,
+      "ssr": true,
+      "module":true
+    }]
+  ]
+}

--- a/test/fixtures/18-preprocess-import-as-module/after.js
+++ b/test/fixtures/18-preprocess-import-as-module/after.js
@@ -1,0 +1,2 @@
+import styled from 'styled-components/dist/no-parser.es';
+require('styled-components/dist/no-parser.es');

--- a/test/fixtures/18-preprocess-import-as-module/before.js
+++ b/test/fixtures/18-preprocess-import-as-module/before.js
@@ -1,0 +1,2 @@
+import styled from 'styled-components';
+require('styled-components');


### PR DESCRIPTION
Setting the `module` option to true will change `require('styled-components/no-parser')`
to `require('styled-components/dist/no-parser.es')`

Since bundlers can't detect the ES module, this should do the trick
What do you think?

Related to styled-components/styled-components#640