### PR TITLE
Upgrade to stylis 3.2 and use constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "displayName"
   ],
   "dependencies": {
-    "stylis": "^3.0.19"
+    "stylis": "^3.2.1"
   }
 }

--- a/src/css/preprocessUtils.js
+++ b/src/css/preprocessUtils.js
@@ -1,5 +1,5 @@
 import * as t from 'babel-types'
-import stylis from 'stylis'
+import Stylis from 'stylis'
 
 import {
   makePlaceholder,
@@ -10,11 +10,7 @@ import {
   fixGlobalPlaceholders,
 } from './placeholderUtils'
 
-// Reset stylis middleware
-stylis.use(null)
-
-// Set stylis options (matching SC options)
-stylis.set({
+const stylis = new Stylis({
   global: false,
   cascade: true,
   keyframe: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2508,9 +2508,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@^3.0.19:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.1.7.tgz#aba33dc3495784ecd768aed8b638a429a2ad2069"
+stylis@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.1.tgz#7a88988f8ccb5c238be3cc3cec173735cc594740"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This prevents bugs with shared options and middleware when different
babel plugins use stylis.

cc @thysultan