### PR TITLE
Sanitize display name to prevent invalid class names

### DIFF
--- a/src/visitors/displayNameAndId.js
+++ b/src/visitors/displayNameAndId.js
@@ -94,9 +94,11 @@ const getComponentId = (state) => {
 
 export default (path, state) => {
   if (isStyled(path.node.tag, state)) {
+    const displayName = useDisplayName(state) && getDisplayName(path, useFileName(state) && state);
+
     addConfig(
       path,
-      useDisplayName(state) && getDisplayName(path, useFileName(state) && state),
+      displayName && displayName.replace(/[^_a-zA-Z0-9-]/g, ''),
       useSSR(state) && getComponentId(state)
     )
   }


### PR DESCRIPTION
Fixes #80

It removes invalid characters from the display name so it can be used as a valid classname.