### PR TITLE
Use file.opts.filename instead of file.opts.basename for babel 7 compatibility

### DIFF
--- a/src/visitors/displayNameAndId.js
+++ b/src/visitors/displayNameAndId.js
@@ -27,9 +27,8 @@ const addConfig = (path, displayName, componentId) => {
 }
 
 const getBlockName = (file) => {
-  return file.opts.basename !== 'index' ?
-    file.opts.basename :
-    path.basename(path.dirname(file.opts.filename))
+  const name = path.basename(file.opts.filename, path.extname(file.opts.filename))
+  return name !== 'index' ? name : path.basename(path.dirname(file.opts.filename))
 }
 
 const getDisplayName = (path, state) => {


### PR DESCRIPTION
https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7-for-tool-authors