### PR TITLE
Use rimraf for cross-platform "rm -rf"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-preset-env": "^1.2.2",
-    "jest": "^17.0.3"
+    "jest": "^17.0.3",
+    "rimraf": "^2.6.2"
   },
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "build": "babel src -d lib",
     "test": "jest",
     "test:watch": "npm run test -- --watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,6 +2388,12 @@ rimraf@2, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"


### PR DESCRIPTION
Hi, I wanted to tackle one of the issues here, but I'm developing on Windows and here's what I get:
```
> rm -rf lib

'rm' is not recognized as an internal or external command,
operable program or batch file.
```

Replacing `rm -rf` with `rimraf` solves the problem.