### PR TITLE
Support Babel v7.0.0-beta.3 (fixes #96).

### DIFF
--- a/test/fixtures/19-transpile-require-default/after.js
+++ b/test/fixtures/19-transpile-require-default/after.js
@@ -3,14 +3,14 @@ const styled_default = require("styled-components/no-parser");
 const TestNormal = styled.div.withConfig({
   displayName: "before__TestNormal",
   componentId: "y0c69d-0"
-})([["{width: 100%;}"]]);
+})([["{width:100%;}"]]);
 
 const Test = styled_default.default.div.withConfig({
   displayName: "before__Test",
   componentId: "y0c69d-1"
-})([["{width: 100%;}"]]);
+})([["{width:100%;}"]]);
 
 const TestCallExpression = styled_default.default(Test).withConfig({
   displayName: "before__TestCallExpression",
   componentId: "y0c69d-2"
-})([["{height: 20px;}"]]);
+})([["{height:20px;}"]]);


### PR DESCRIPTION
Adds path traversal logic unceremoniously cribbed from lodash/babel-plugin-lodash#194 to replace the built-in import tracking that was removed in Babel v7.0.0-beta.3.