### PR TITLE
Preserve comments that begin with "/*!"

### DIFF
--- a/src/minify/index.js
+++ b/src/minify/index.js
@@ -1,6 +1,6 @@
 import { makePlaceholder, splitByPlaceholders } from '../css/placeholderUtils'
 
-const makeMultilineCommentRegex = newlinePattern => new RegExp('\\/\\*(.|' + newlinePattern + ')*?\\*\\/', 'g')
+const makeMultilineCommentRegex = newlinePattern => new RegExp('\\/\\*[^!](.|' + newlinePattern + ')*?\\*\\/', 'g')
 const lineCommentStart = /\/\//g
 const symbolRegex = /(\s*[;:{},]\s*)/g
 

--- a/test/fixtures/18-preprocess-inject-global/after.js
+++ b/test/fixtures/18-preprocess-inject-global/after.js
@@ -1,1 +1,1 @@
-injectGlobal([["", glob, "\nhtml,body{margin:100000px;padding:", test, ";}@media (max-width:999px){html,body{margin:0;}}.root{width:100%;}"]]);
+injectGlobal([["", glob, "\n/*! preserve comment */html,body{margin:100000px;padding:", test, ";}@media (max-width:999px){html,body{margin:0;}}.root{width:100%;}"]]);

--- a/test/fixtures/18-preprocess-inject-global/before.js
+++ b/test/fixtures/18-preprocess-inject-global/before.js
@@ -1,6 +1,10 @@
 injectGlobal`
   ${glob}
 
+  // comment
+  /* comment */
+  /*! preserve comment */
+
   html, body {
     margin: 100000px;
     padding: ${test};

--- a/test/fixtures/19-transpile-require-default/after.js
+++ b/test/fixtures/19-transpile-require-default/after.js
@@ -3,14 +3,14 @@ const styled_default = require("styled-components/no-parser");
 const TestNormal = styled.div.withConfig({
   displayName: "before__TestNormal",
   componentId: "y0c69d-0"
-})([["{width: 100%;}"]]);
+})([["{width:100%;}"]]);
 
 const Test = styled_default.default.div.withConfig({
   displayName: "before__Test",
   componentId: "y0c69d-1"
-})([["{width: 100%;}"]]);
+})([["{width:100%;}"]]);
 
 const TestCallExpression = styled_default.default(Test).withConfig({
   displayName: "before__TestCallExpression",
   componentId: "y0c69d-2"
-})([["{height: 20px;}"]]);
+})([["{height:20px;}"]]);

--- a/test/minify/index.test.js
+++ b/test/minify/index.test.js
@@ -61,6 +61,15 @@ describe('minify utils', () => {
       expect(actual).toBe(expected)
       expect(actual).toBe(minifyCooked(input))
     })
+
+    it('Preserves multi-line comments starting with /*!', () => {
+      const input = 'this is a /*! dont ignore me please */ test/* but you can ignore me */'
+      const expected = 'this is a /*! dont ignore me please */ test'
+      const actual = minifyRaw(input)
+
+      expect(actual).toBe(expected)
+      expect(actual).toBe(minifyCooked(input))
+    })
   })
 
   describe('minifyRaw', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,14 +629,7 @@ babel-register@^6.24.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -667,16 +660,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -2382,13 +2366,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@^2.6.2:
+rimraf@2, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -2534,9 +2512,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@3.x:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.3.2.tgz#95ef285836e98243f8b8f64a9a72706ea6c893ea"
+stylis@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -2590,10 +2568,6 @@ throat@^3.0.0:
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-
-to-fast-properties@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Add an exception to preserve comments that begin with `/*!`

Related to https://github.com/styled-components/styled-components/issues/1249