### PR TITLE
Add option for css namespaces in styled-components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import minify from './visitors/minify'
-import displayNameAndId from './visitors/displayNameAndId'
+import displayNameIdAndNamespace from './visitors/displayNameIdAndNamespace'
 import templateLiterals from './visitors/templateLiterals'
 import assignStyledRequired from './visitors/assignStyledRequired'
 import { noParserImportDeclaration, noParserRequireCallExpression } from './visitors/noParserImport'
@@ -15,7 +15,7 @@ export default function({ types: t }) {
       },
       TaggedTemplateExpression(path, state) {
         minify(path, state)
-        displayNameAndId(path, state)
+        displayNameIdAndNamespace(path, state)
         templateLiterals(path, state)
       },
       VariableDeclarator(path, state) {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -3,8 +3,9 @@ function getOption({ opts }, name, defaultValue = true) {
 }
 
 export const useDisplayName = (state) => getOption(state, 'displayName')
-export const useSSR = (state) =>  getOption(state, 'ssr', false)
-export const useFileName = (state) =>getOption(state, 'fileName')
+export const useSSR = (state) => getOption(state, 'ssr', false)
+export const useFileName = (state) => getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL
 export const useTranspileTemplateLiterals = (state) => getOption(state, 'transpileTemplateLiterals')
+export const useNamespaceClasses = state => getOption(state, 'namespaceClasses', null);


### PR DESCRIPTION
Works with https://github.com/styled-components/styled-components/pull/1260 to fix issue https://github.com/styled-components/styled-components/issues/613

This allows someone to pass in an additional property to add css namespaces to increase the specificity of styles applied to styled components.

It is a no-op until https://github.com/styled-components/styled-components/pull/1260 is approved and merged.

``` json
{
  "plugins": [
    ["babel-plugin-styled-components", {
      "namespaceClasses": "moreSpecific"
    }]
  ]
}
```
adds the namespace to all styled-components
``` css
.moreSpecific .mx12n49 {
  background-color: yellow;
}
```

or for a list of classes
``` json
{
  "plugins": [
    ["babel-plugin-styled-components", {
      "namespaceClasses": ["moreSpecific", "verySpecific"]
    }]
  ]
}
```
``` css
.moreSpecific .verySpecific .mx12n49 {
  background-color: yellow;
}
```