### PR TITLE
deps: upgrade stylis, fix semver range notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   ],
   "dependencies": {
     "babel-types": "^6.26.0",
-    "stylis": "3.x"
+    "stylis": "^3.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,7 +2512,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@3.x:
+stylis@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
 


### PR DESCRIPTION
I think there was something about the "3.x" syntax that was causing
this subdependency from being  automatically updated externally.

In my own projects, when running npm update I have not been getting
automatic stylis updates as they are released.