### PR TITLE
feat: add url prefix option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 lib
+.DS_Store

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -8,3 +8,4 @@ export const useFileName = (state) =>getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL
 export const useTranspileTemplateLiterals = (state) => getOption(state, 'transpileTemplateLiterals')
+export const useURLPrefix = (state) => getOption(state, 'urlPrefix', false)

--- a/src/visitors/templateLiterals/index.js
+++ b/src/visitors/templateLiterals/index.js
@@ -1,12 +1,20 @@
 import {
   useCSSPreprocessor,
-  useTranspileTemplateLiterals
+  useTranspileTemplateLiterals,
+  useURLPrefix
 } from '../../utils/options'
 
 import preprocess from './preprocess'
 import transpile from './transpile'
+import urlPrefix from './urlPrefix'
 
 export default (path, state) => {
+  // Conditionally parse `url()` statements in CSS attributes
+  // and replace them with absolute URLs
+  if (useURLPrefix(state)) {
+    urlPrefix(path, state)
+  }
+
   // We can only do one or the other, but preprocessing
   // disables the normal transpilation, obviously
   if (useCSSPreprocessor(state)) {

--- a/src/visitors/templateLiterals/urlPrefix.js
+++ b/src/visitors/templateLiterals/urlPrefix.js
@@ -4,6 +4,23 @@ import { useURLPrefix } from '../../utils/options'
 
 const RELATIVE_URL_REGEX = /(\/)(\w|\d|\s|\/)*(.svg|.png|.jpg|.jpeg|.gif)/g
 
+export const prefixRelativeURLs = (prefix) => (element) => {
+  const { type, value } = element
+  const relativeURLs = value.match(RELATIVE_URL_REGEX) || []
+
+  let transformedValue = value
+  for (let i = 0; i < relativeURLs.length; ++i) {
+    const relativeURL = relativeURLs[i]
+    const absoluteURL = prefix + relativeURL
+
+    // Note: Swap in the prefixed URL
+    transformedValue = transformedValue
+      .replace(relativeURL, absoluteURL)
+  }
+ 
+  return { type, value: transformedValue }
+}
+
 export default (path, state) => {
   if (
     isStyled(path.node.tag, state)
@@ -12,23 +29,8 @@ export default (path, state) => {
    
     const { tag: callee, quasi: { quasis, expressions }} = path.node
     const values = t.arrayExpression(quasis.map(quasi => t.stringLiteral(quasi.value.cooked)))
-    
-    const transformedElements = values.elements.map(elem => {
-      const { type, value } = elem
-      const relativeURLs = value.match(RELATIVE_URL_REGEX) || []
-
-      let transformedValue = value
-      for (let i = 0; i < relativeURLs.length; ++i) {
-        const relativeURL = relativeURLs[i]
-        const absoluteURL = urlPrefix + relativeURL
-
-        // Note: Swap in the prefixed URL
-        transformedValue = transformedValue
-          .replace(relativeURL, absoluteURL)
-      }
-     
-      return { type, value: transformedValue }
-    })
+    const prefixURLs = prefixRelativeURLs(urlPrefix)
+    const transformedElements = values.elements.map(prefixURLs)
 
     values.elements = transformedElements
 

--- a/src/visitors/templateLiterals/urlPrefix.js
+++ b/src/visitors/templateLiterals/urlPrefix.js
@@ -1,0 +1,37 @@
+import * as t from 'babel-types'
+import { isStyled, isHelper } from '../../utils/detectors'
+import { useURLPrefix } from '../../utils/options'
+
+const RELATIVE_URL_REGEX = /(\/)(\w|\d|\s|\/)*(.svg|.png|.jpg|.jpeg|.gif)/g
+
+export default (path, state) => {
+  if (
+    isStyled(path.node.tag, state)
+  ) {
+    const urlPrefix = useURLPrefix(state)
+   
+    const { tag: callee, quasi: { quasis, expressions }} = path.node
+    const values = t.arrayExpression(quasis.map(quasi => t.stringLiteral(quasi.value.cooked)))
+    
+    const transformedElements = values.elements.map(elem => {
+      const { type, value } = elem
+      const relativeURLs = value.match(RELATIVE_URL_REGEX) || []
+
+      let transformedValue = value
+      for (let i = 0; i < relativeURLs.length; ++i) {
+        const relativeURL = relativeURLs[i]
+        const absoluteURL = urlPrefix + relativeURL
+
+        // Note: Swap in the prefixed URL
+        transformedValue = transformedValue
+          .replace(relativeURL, absoluteURL)
+      }
+     
+      return { type, value: transformedValue }
+    })
+
+    values.elements = transformedElements
+
+    path.replaceWith(t.callExpression(callee, [ values, ...expressions ]))
+  }
+}

--- a/test/fixtures/20-insert-url-prefix/.babelrc
+++ b/test/fixtures/20-insert-url-prefix/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "urlPrefix": "https://foo.com"
+    }]
+  ]
+}

--- a/test/fixtures/20-insert-url-prefix/after.js
+++ b/test/fixtures/20-insert-url-prefix/after.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const WithURL = styled.div.withConfig({
+  displayName: 'before__WithURL'
+})(['background:url(\'https://foo.com/images/bar.png\') no-repeat center center;']);
+
+const WithURLNested = styled(WithURL).withConfig({
+  displayName: 'before__WithURLNested'
+})(['background:url(\'https://foo.com/images/baz.png\') no-repeat center center;']);

--- a/test/fixtures/20-insert-url-prefix/before.js
+++ b/test/fixtures/20-insert-url-prefix/before.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const WithURL = styled.div`
+  background: url('/images/bar.png') no-repeat center center;
+`;
+
+const WithURLNested = styled(WithURL)`
+  background: url('/images/baz.png') no-repeat center center;
+`;


### PR DESCRIPTION
## What

This adds support for a `urlPrefix` option. When supplied, the url prefix will be added to all paths inside of `url(...)` declarations defined by styled-components. It's like Webpacks `baseUrl` for your styled-components!

For example, `url('/images/foo.png')` would become `url('https://bar.com/images/foo.png')`.

## Why

To support the serving of assets from a different domain than that serving the app.

## Other

Would be great if you guys want to support this. Our team has found it to be useful with our current deployment architecture. Also, this is my first time working with Babel plugins so I wouldn't be surprised if I missed something.

