### PR TITLE
disable "uglifyPure" mode by default

### DIFF
--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -8,4 +8,4 @@ export const useFileName = (state) =>getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL
 export const useTranspileTemplateLiterals = (state) => getOption(state, 'transpileTemplateLiterals')
-export const useUglifyPure = (state) => getOption(state, 'uglifyPure')
+export const useUglifyPure = (state) => getOption(state, 'uglifyPure', false)

--- a/test/fixtures/20-annotate-styled-calls-with-uglify-pure-comments/.babelrc
+++ b/test/fixtures/20-annotate-styled-calls-with-uglify-pure-comments/.babelrc
@@ -5,6 +5,7 @@
       "fileName": false,
       "transpileTemplateLiterals": false,
       "preprocess": false,
+      "uglifyPure": true
     }]
   ]
 }

--- a/test/fixtures/21-annotate-keyframes-with-uglify-pure-comments/.babelrc
+++ b/test/fixtures/21-annotate-keyframes-with-uglify-pure-comments/.babelrc
@@ -3,6 +3,7 @@
     ["../../../src", {
       "preprocess": true,
       "ssr": true,
+      "uglifyPure": true
     }]
   ]
 }


### PR DESCRIPTION
unfortunately this feature seems to dramatically inflate the
amount of time babel takes to process files... perhaps there is
an unintended loop happening or something of the like

fixes #126