### PR TITLE
New Option: cssTemplate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import uglifyPure from './visitors/uglifyPure'
 import minify from './visitors/minify'
 import displayNameAndId from './visitors/displayNameAndId'
 import templateLiterals from './visitors/templateLiterals'
+import cssTemplate from './visitors/cssTemplate'
 import assignStyledRequired from './visitors/assignStyledRequired'
 import { noParserImportDeclaration, noParserRequireCallExpression } from './visitors/noParserImport'
 
@@ -20,6 +21,7 @@ export default function({ types: t }) {
         minify(path, state)
         displayNameAndId(path, state)
         templateLiterals(path, state)
+        cssTemplate(path, state)
       },
       VariableDeclarator(path, state) {
         assignStyledRequired(path, state)

--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -71,3 +71,8 @@ export const isHelper = (tag, state) => (
   isCSSHelper(tag, state) ||
   isKeyframesHelper(tag, state)
 )
+
+export const isExtend = (tag, state) => (
+  t.isMemberExpression(tag) &&
+  tag.property.name === 'extend'
+)

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -3,9 +3,11 @@ function getOption({ opts }, name, defaultValue = true) {
 }
 
 export const useDisplayName = (state) => getOption(state, 'displayName')
-export const useSSR = (state) =>  getOption(state, 'ssr', false)
-export const useFileName = (state) =>getOption(state, 'fileName')
+export const useSSR = (state) => getOption(state, 'ssr', false)
+export const useFileName = (state) => getOption(state, 'fileName')
 export const useMinify = (state) => getOption(state, 'minify')
 export const useCSSPreprocessor = (state) => getOption(state, 'preprocess', false) // EXPERIMENTAL
 export const useTranspileTemplateLiterals = (state) => getOption(state, 'transpileTemplateLiterals')
 export const useUglifyPure = (state) => getOption(state, 'uglifyPure', false)
+const cssTemplateDefaults = { styled: false, css: false, injectGlobal: false }
+export const useCssTemplate = (state) => Object.assign({}, cssTemplateDefaults, getOption(state, 'cssTemplate', {}))

--- a/src/visitors/cssTemplate.js
+++ b/src/visitors/cssTemplate.js
@@ -1,0 +1,51 @@
+import { useCssTemplate } from '../utils/options'
+import { isStyled, isCSSHelper, isInjectGlobalHelper, isExtend } from '../utils/detectors'
+import { makePlaceholder, splitByPlaceholders } from '../css/placeholderUtils'
+
+const CSS_PLACEHOLDER = '{css}'
+
+// Replace the first instance of {css}. Remove any other instances.
+// There is an issue with replacing all instances and multiple interpolations
+export const templateCss = (cssTemplate, css) => {
+  if (cssTemplate.indexOf(CSS_PLACEHOLDER) === -1) {
+    return css;
+  }
+  return cssTemplate.replace(CSS_PLACEHOLDER, css).split(CSS_PLACEHOLDER).join('')
+}
+
+export const templateValues = (cssTemplate, values) => splitByPlaceholders(
+  templateCss(
+    cssTemplate,
+    values.join(makePlaceholder(321))
+  ),
+  false
+)
+
+const applyCssTemplate = (cssTemplate, node) => {
+  const templateLiteral = node.quasi
+  const quasisLength = templateLiteral.quasis.length
+  
+  const rawValuesPrepended = templateValues(cssTemplate, templateLiteral.quasis.map(x => x.value.raw))
+  const cookedValuesPrepended = templateValues(cssTemplate, templateLiteral.quasis.map(x => x.value.cooked))
+
+  for (let i = 0; i < quasisLength; i++) {
+    const element = templateLiteral.quasis[i]
+
+    element.value.raw = rawValuesPrepended[i]
+    element.value.cooked = cookedValuesPrepended[i]
+  }
+}
+
+export default ({ node }, state) => {
+  const { styled, css, injectGlobal } = useCssTemplate(state);
+  const templateStyled = styled && (isStyled(node.tag, state) || isExtend(node.tag, state));
+  const templateCssHelper = css && isCSSHelper(node.tag, state);
+  const templateInjectGlobal = injectGlobal && isInjectGlobalHelper(node.tag, state);
+  if (templateStyled) {
+    applyCssTemplate(styled, node)
+  } else if (templateCssHelper) {
+    applyCssTemplate(css, node)
+  } else if (templateInjectGlobal) {
+    applyCssTemplate(injectGlobal, node)
+  }
+}

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -259,6 +259,136 @@ exports[`fixtures should preprocess inject global 1`] = `"injectGlobal([[\"\", g
 
 exports[`fixtures should preprocess keyframes 1`] = `"const Animation = keyframes([[\"@-webkit-keyframes \"], [\"{0%{opacity:0;}100%{opacity:1;}}@keyframes \"], [\"{0%{opacity:0;}100%{opacity:1;}}\"]]);"`;
 
+exports[`fixtures should template css helper 1`] = `
+"const Simple = css\`#id {width: 100%; } \`;
+
+const Nested = css\`#id {
+  width: 100%;
+
+  &:hover {
+    color: papayawhip;
+  }
+
+  > div {
+    background: white;
+  }
+ } \`;
+
+const Interpolations = css\`#id {
+  width: \${props => props.width};
+ } \`;
+
+const NestedAndInterpolations = css\`#id {
+  width: \${props => props.width};
+
+  &:hover {
+    color: \${props => props.color};
+  }
+ } \`;
+
+const SelectorInterpolation = css\`#id {
+  width: \${props => props.width};
+
+  \${props => props.selector} {
+    color: papayawhip;
+  }
+ } \`;
+
+const Styled = styled.div\`width: 100%\`;"
+`;
+
+exports[`fixtures should template inject global 1`] = `
+"injectGlobal\`#id > {
+  \${glob}
+
+  // comment
+  /* comment */
+  /*! preserve comment */
+
+  html, body {
+    margin: 100000px;
+    padding: \${test};
+
+    @media (max-width: 999px) {
+      margin: 0;
+    }
+  }
+
+  .root {
+    width: 100%;
+  }
+}\`;
+
+const Simple = css\`width: 100%;\`;
+
+const Styled = styled.div\`width: 100%\`;"
+`;
+
+exports[`fixtures should template styled 1`] = `
+"const Simple = styled.div\`#id && {width: 100%;}\`;
+
+const Nested = styled.div\`#id && {
+  width: 100%;
+
+  &:hover {
+    color: papayawhip;
+  }
+
+  > div {
+    background: white;
+  }
+}\`;
+
+const Interpolations = styled.div\`#id && {
+  width: \${props => props.width};
+}\`;
+
+const NestedAndInterpolations = styled.div\`#id && {
+  width: \${props => props.width};
+
+  &:hover {
+    color: \${props => props.color};
+  }
+}\`;
+
+const SelectorInterpolation = styled.div\`#id && {
+  width: \${props => props.width};
+
+  \${props => props.selector} {
+    color: papayawhip;
+  }
+}\`;
+
+const CssHelper = css\`width: 100%\`;"
+`;
+
+exports[`fixtures should template styled css inject global 1`] = `
+"injectGlobal\`* {
+  \${glob}
+
+  // comment
+  /* comment */
+  /*! preserve comment */
+
+  html, body {
+    margin: 100000px;
+    padding: \${test};
+
+    @media (max-width: 999px) {
+      margin: 0;
+    }
+  }
+
+  .root {
+    width: 100%;
+  }
+}\`;
+
+const Simple = css\`#id && {width: 100%;}\`;
+
+const Styled = styled.div\`#id {width: 100%}\`;"
+`;
+
 exports[`fixtures should track the imported variable 1`] = `
 "import s from \"styled-components\";
 

--- a/test/fixtures/23-template-styled/.babelrc
+++ b/test/fixtures/23-template-styled/.babelrc
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "displayName": false,
+      "ssr": false,
+      "fileName": false,
+      "minify": false,
+      "preprocess": false,
+      "transpileTemplateLiterals": false,
+      "cssTemplate": {
+        "styled": "#id && {{css}}"
+      }
+    }]
+  ]
+}

--- a/test/fixtures/23-template-styled/before.js
+++ b/test/fixtures/23-template-styled/before.js
@@ -1,0 +1,35 @@
+const Simple = styled.div`width: 100%;`;
+
+const Nested = styled.div`
+  width: 100%;
+
+  &:hover {
+    color: papayawhip;
+  }
+
+  > div {
+    background: white;
+  }
+`;
+
+const Interpolations = styled.div`
+  width: ${props => props.width};
+`;
+
+const NestedAndInterpolations = styled.div`
+  width: ${props => props.width};
+
+  &:hover {
+    color: ${props => props.color};
+  }
+`;
+
+const SelectorInterpolation = styled.div`
+  width: ${props => props.width};
+
+  ${props => props.selector} {
+    color: papayawhip;
+  }
+`;
+
+const CssHelper = css`width: 100%`;

--- a/test/fixtures/24-template-css-helper/.babelrc
+++ b/test/fixtures/24-template-css-helper/.babelrc
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "displayName": false,
+      "ssr": false,
+      "fileName": false,
+      "minify": false,
+      "preprocess": false,
+      "transpileTemplateLiterals": false,
+      "cssTemplate": {
+        "css": "#id {{css} {css}} {css}"
+      }
+    }]
+  ]
+}

--- a/test/fixtures/24-template-css-helper/before.js
+++ b/test/fixtures/24-template-css-helper/before.js
@@ -1,0 +1,35 @@
+const Simple = css`width: 100%;`;
+
+const Nested = css`
+  width: 100%;
+
+  &:hover {
+    color: papayawhip;
+  }
+
+  > div {
+    background: white;
+  }
+`;
+
+const Interpolations = css`
+  width: ${props => props.width};
+`;
+
+const NestedAndInterpolations = css`
+  width: ${props => props.width};
+
+  &:hover {
+    color: ${props => props.color};
+  }
+`;
+
+const SelectorInterpolation = css`
+  width: ${props => props.width};
+
+  ${props => props.selector} {
+    color: papayawhip;
+  }
+`;
+
+const Styled = styled.div`width: 100%`;

--- a/test/fixtures/25-template-inject-global/.babelrc
+++ b/test/fixtures/25-template-inject-global/.babelrc
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "displayName": false,
+      "ssr": false,
+      "fileName": false,
+      "minify": false,
+      "preprocess": false,
+      "transpileTemplateLiterals": false,
+      "cssTemplate": {
+        "injectGlobal": "#id > {{css}}"
+      }
+    }]
+  ]
+}

--- a/test/fixtures/25-template-inject-global/before.js
+++ b/test/fixtures/25-template-inject-global/before.js
@@ -1,0 +1,24 @@
+injectGlobal`
+  ${glob}
+
+  // comment
+  /* comment */
+  /*! preserve comment */
+
+  html, body {
+    margin: 100000px;
+    padding: ${test};
+
+    @media (max-width: 999px) {
+      margin: 0;
+    }
+  }
+
+  .root {
+    width: 100%;
+  }
+`;
+
+const Simple = css`width: 100%;`;
+
+const Styled = styled.div`width: 100%`;

--- a/test/fixtures/26-template-styled-css-inject-global/.babelrc
+++ b/test/fixtures/26-template-styled-css-inject-global/.babelrc
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    ["../../../src", {
+      "displayName": false,
+      "ssr": false,
+      "fileName": false,
+      "minify": false,
+      "preprocess": false,
+      "transpileTemplateLiterals": false,
+      "cssTemplate": {
+        "styled": "#id {{css}}",
+        "css": "#id && {{css}}",
+        "injectGlobal": "* {{css}}"
+      }
+    }]
+  ]
+}

--- a/test/fixtures/26-template-styled-css-inject-global/before.js
+++ b/test/fixtures/26-template-styled-css-inject-global/before.js
@@ -1,0 +1,24 @@
+injectGlobal`
+  ${glob}
+
+  // comment
+  /* comment */
+  /*! preserve comment */
+
+  html, body {
+    margin: 100000px;
+    padding: ${test};
+
+    @media (max-width: 999px) {
+      margin: 0;
+    }
+  }
+
+  .root {
+    width: 100%;
+  }
+`;
+
+const Simple = css`width: 100%;`;
+
+const Styled = styled.div`width: 100%`;

--- a/test/visitors/cssTemplate.test.js
+++ b/test/visitors/cssTemplate.test.js
@@ -1,0 +1,19 @@
+import {
+  templateCss,
+} from '../../src/visitors/cssTemplate'
+
+describe('css template functions', () => {
+  describe('templateCss', () => {
+    it('replace {css} in the template with the original css', () => {
+      expect(templateCss('abc {css} ghi', 'def')).toBe('abc def ghi')
+    })
+
+    it('replace the first instance of {css} in the template and remove additional', () => {
+      expect(templateCss('abc {css} {css} ghi {css}', 'def')).toBe('abc def  ghi ')
+    })
+
+    it('if there is no {css} in the template return the original css', () => {
+      expect(templateCss('abc ghi', 'def')).toBe('def')
+    })
+  })
+})


### PR DESCRIPTION
I am part of team that has created a react-based website that is embeddable on other websites. We use and **love** styled-components however we frequently have our styles inadvertently overridden by the sites that host our content. The main issue is the specificity of the class selectors added by styled-components combined with our reluctance to use injectGlobal — it would most-likely override the styles on the site embedding our content.

Does that make sense? 

The most straightforward way to fix this is to wrap all of our styles in somethings like `&& { /* our style here */ }`. The issue with this approach has been enforcement as the size of our code-base grows.

So I figured I would write a babel plugin that did it for us and _hopefully_  do it in such a way that others would be able to use it as well.

One thing I know is missing from this PR is formal documentation. I will gladly add that once I know where it should go.
