### PR TITLE
chore: remove sc peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"
   },
-  "peerDependencies": {
-    "styled-components": ">= 2"
-  },
   "scripts": {
     "clean": "rimraf lib",
     "style": "prettier --write src/**/*.js",


### PR DESCRIPTION
Remove npm warning if I want to create a custom babel preset as a **npm library** with `babel-plugin-styled-components`:

```bash
warning " > babel-plugin-styled-components@1.10.0" has unmet peer dependency "styled-components@>= 2".
```