### PR TITLE
feat: read environment specific configuration

### DIFF
--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -1,7 +1,9 @@
 function getOption({ opts }, name, defaultValue = true) {
-  return opts[name] === undefined || opts[name] === null
+  const envOrDefault = opts.env ? opts.env[process.env.NODE_ENV] || opts : opts
+
+  return envOrDefault[name] === undefined || envOrDefault[name] === null
     ? defaultValue
-    : opts[name]
+    : envOrDefault[name]
 }
 
 export const useDisplayName = state => getOption(state, 'displayName')


### PR DESCRIPTION
It would be great if babel-plugin-styled-components could read environment specific option when using via `babel-plugin-macros` instead of directly using this plugin.

As far as i know, `babel-plugin-macros` supports configuration via `cosmiconfig` from package.json or various .rc or .config files, but it doesn't allow environment specifics.

I'd love to use styled-components via macros without configuring this plugin manually, but still be able to do things like `{ displayName: true }` in development and `{ displayName: false }` in production.

This PR enables that usecase.