### PR TITLE
Support nested + lowercase components

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -39,7 +39,7 @@ export default t => (path, state) => {
   )
 
   const styled = t.callExpression(importName, [
-    /^[a-z]/.test(name) ? t.stringLiteral(name) : t.identifier(name),
+    /^[a-z][a-z0-9]*$/.test(name) ? t.stringLiteral(name) : t.identifier(name),
   ])
 
   let css

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -3,6 +3,8 @@
 import { addDefault } from '@babel/helper-module-imports'
 import { useCssProp } from '../utils/options'
 
+const TAG_NAME_REGEXP = /^[a-z][a-z\d]*(\-[a-z][a-z\d]*)?$/
+
 const getName = (node, t) => {
   if (typeof node.name === 'string') return node.name
   if (t.isJSXMemberExpression(node)) {
@@ -39,7 +41,7 @@ export default t => (path, state) => {
   )
 
   const styled = t.callExpression(importName, [
-    /^[a-z][a-z0-9]*$/.test(name) ? t.stringLiteral(name) : t.identifier(name),
+    TAG_NAME_REGEXP.test(name) ? t.stringLiteral(name) : t.identifier(name),
   ])
 
   let css

--- a/test/fixtures/transpile-css-prop/code.js
+++ b/test/fixtures/transpile-css-prop/code.js
@@ -92,3 +92,5 @@ const CustomCompWithDot = p => <Button.Ghost css="flex: 1">H</Button.Ghost>
 const NestedCompWithDot = p => (
   <Button.Ghost.New css="flex: 1">H</Button.Ghost.New>
 )
+
+const CustomCompWithDotLowerCase = p => <button.ghost css="flex: 1">H</button.ghost>

--- a/test/fixtures/transpile-css-prop/code.js
+++ b/test/fixtures/transpile-css-prop/code.js
@@ -94,3 +94,5 @@ const NestedCompWithDot = p => (
 )
 
 const CustomCompWithDotLowerCase = p => <button.ghost css="flex: 1">H</button.ghost>
+
+const CustomElement = p => <button-ghost css="flex: 1">H</button-ghost>

--- a/test/fixtures/transpile-css-prop/output.js
+++ b/test/fixtures/transpile-css-prop/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _templateObject19() {
+  var data = _taggedTemplateLiteral(["flex: 1"]);
+
+  _templateObject19 = function _templateObject19() {
+    return data;
+  };
+
+  return data;
+}
+
 function _templateObject18() {
   var data = _taggedTemplateLiteral(["flex: 1"]);
 
@@ -271,6 +281,10 @@ var CustomCompWithDotLowerCase = function CustomCompWithDotLowerCase(p) {
   return <_StyledButtonGhost2>H</_StyledButtonGhost2>;
 };
 
+var CustomElement = function CustomElement(p) {
+  return <_StyledButtonGhost3>H</_StyledButtonGhost3>;
+};
+
 var _StyledP = (0, _styledComponents.default)("p")(_templateObject4());
 
 var _StyledP2 = (0, _styledComponents.default)("p")(_templateObject5());
@@ -312,3 +326,5 @@ var _StyledButtonGhost = (0, _styledComponents.default)(Button.Ghost)(_templateO
 var _StyledButtonGhostNew = (0, _styledComponents.default)(Button.Ghost.New)(_templateObject17());
 
 var _StyledButtonGhost2 = (0, _styledComponents.default)(button.ghost)(_templateObject18());
+
+var _StyledButtonGhost3 = (0, _styledComponents.default)("button-ghost")(_templateObject19());

--- a/test/fixtures/transpile-css-prop/output.js
+++ b/test/fixtures/transpile-css-prop/output.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function _templateObject18() {
+  var data = _taggedTemplateLiteral(["flex: 1"]);
+
+  _templateObject18 = function _templateObject18() {
+    return data;
+  };
+
+  return data;
+}
+
 function _templateObject17() {
   var data = _taggedTemplateLiteral(["flex: 1"]);
 
@@ -257,6 +267,10 @@ var NestedCompWithDot = function NestedCompWithDot(p) {
   return <_StyledButtonGhostNew>H</_StyledButtonGhostNew>;
 };
 
+var CustomCompWithDotLowerCase = function CustomCompWithDotLowerCase(p) {
+  return <_StyledButtonGhost2>H</_StyledButtonGhost2>;
+};
+
 var _StyledP = (0, _styledComponents.default)("p")(_templateObject4());
 
 var _StyledP2 = (0, _styledComponents.default)("p")(_templateObject5());
@@ -296,3 +310,5 @@ var _StyledP11 = (0, _styledComponents.default)("p")(_templateObject15(), functi
 var _StyledButtonGhost = (0, _styledComponents.default)(Button.Ghost)(_templateObject16());
 
 var _StyledButtonGhostNew = (0, _styledComponents.default)(Button.Ghost.New)(_templateObject17());
+
+var _StyledButtonGhost2 = (0, _styledComponents.default)(button.ghost)(_templateObject18());


### PR DESCRIPTION
This is to support the [Animated](https://github.com/animatedjs/animated) library used by [react-spring](https://www.react-spring.io/) with the `css` prop.

Pseudocode to illustrate:

```jsx
// in
<animated.div css="color: red" />
```

```jsx
// out (before the change)
styled("animated.div")`
  color: red
`
```

```jsx
// out (after the change)
styled(animated.div)`
  color: red
`
```
