### PR TITLE
Replace Object.entries with Object.keys for better node compatibility

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -84,8 +84,8 @@ export default t => (path, state) => {
 
   css.expressions = css.expressions.reduce((acc, ex) => {
     if (
-      Object.entries(bindings).some(([, b] /*: any */) =>
-        b.referencePaths.find(p => p.node === ex)
+      Object.keys(bindings).some(key =>
+        bindings[key].referencePaths.find(p => p.node === ex)
       ) ||
       t.isFunctionExpression(ex) ||
       t.isArrowFunctionExpression(ex)


### PR DESCRIPTION
I ran into an "Object.entries not a function" error when setting up `babel-plugin-styled-components` in node `6.12.2`.  Turns out [`Object.entries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Browser_compatibility) is only supported in node `7.0.0+`. Even though this project's `babelrc` [targets node `4`](https://github.com/styled-components/babel-plugin-styled-components/blob/master/.babelrc#L6-L8), it is not setup to polyfill methods like `Object.entries`. Luckily, `Object.entries` is only used once. I think the easiest solution is to replace the single use of `Object.entries` with a call to `Object.keys` instead.