### PR TITLE
Fix `importName` type confusion (string, bool, node)

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -29,7 +29,7 @@ export default t => (path, state) => {
   const { bindings } = program.scope
 
   // Insert import if it doesn't exist yet
-  if (!importName || !bindings[importName.name]) {
+  if (!importName || !bindings[importName.name] || !bindings[importName]) {
     addDefault(path, 'styled-components', {
       nameHint: 'styled',
     })


### PR DESCRIPTION
Apparently `importName` can have many different types:
https://github.com/styled-components/babel-plugin-styled-components/issues/232#issuecomment-507223968

This commit ensures that the check whether the name is in the scope
(bindings) does not break on plain strings.

Closes: #232