### PR TITLE
[Security] Bump lodash from 4.17.11 to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/helper-annotate-as-pure": "^7.0.0",
     "@babel/helper-module-imports": "^7.0.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.15"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,6 +2935,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
Updated to the latest published `lodash` version to address [Snyk#1065](https://www.npmjs.com/advisories/1065). I could've just bumped to `^4.17.12` as per the advisory, but figured I might as well use the latest version.