### PR TITLE
Added test for transpiling css prop as an array

### DIFF
--- a/test/fixtures/transpile-css-prop/code.js
+++ b/test/fixtures/transpile-css-prop/code.js
@@ -106,3 +106,13 @@ const EarlyUsageComponent = p => <Thing3 css="color: red;" />
 const Thing3 = styled.div`
   color: blue;
 `
+
+const styledMixin1 = css`
+  color: tomato;
+`
+
+const styledMixin2 = css`
+  font-size: 122px;
+`
+
+const ArrayCssHelperProp = p => <p css={[styledMixin1, styledMixin2]}>A</p>

--- a/test/fixtures/transpile-css-prop/code.js
+++ b/test/fixtures/transpile-css-prop/code.js
@@ -108,11 +108,11 @@ const Thing3 = styled.div`
 `
 
 const styledMixin1 = css`
-  color: tomato;
+  color: red;
 `
 
 const styledMixin2 = css`
-  font-size: 122px;
+  font-size: 10px;
 `
 
 const ArrayCssHelperProp = p => <p css={[styledMixin1, styledMixin2]}>A</p>

--- a/test/fixtures/transpile-css-prop/output.js
+++ b/test/fixtures/transpile-css-prop/output.js
@@ -4,6 +4,36 @@ var _styledComponents = _interopRequireDefault(require("styled-components"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _templateObject20() {
+  var data = _taggedTemplateLiteral(["", ""]);
+
+  _templateObject20 = function _templateObject20() {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject19() {
+  var data = _taggedTemplateLiteral(["\n  font-size: 122px;\n"]);
+
+  _templateObject19 = function _templateObject19() {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject18() {
+  var data = _taggedTemplateLiteral(["\n  color: tomato;\n"]);
+
+  _templateObject18 = function _templateObject18() {
+    return data;
+  };
+
+  return data;
+}
+
 function _templateObject17() {
   var data = _taggedTemplateLiteral(["color: red;"]);
 
@@ -316,3 +346,14 @@ var EarlyUsageComponent = function EarlyUsageComponent(p) {
 var Thing3 = styled.div(_templateObject16());
 
 var _StyledThing = (0, _styledComponents["default"])(Thing3)(_templateObject17());
+
+var styledMixin1 = css(_templateObject18());
+var styledMixin2 = css(_templateObject19());
+
+var _StyledP12 = (0, _styledComponents["default"])("p")(_templateObject20(), function (p) {
+  return p._css4;
+});
+
+var ArrayCssHelperProp = function ArrayCssHelperProp(p) {
+  return <_StyledP12 _css4={[styledMixin1, styledMixin2]}>A</_StyledP12>;
+};

--- a/test/fixtures/transpile-css-prop/output.js
+++ b/test/fixtures/transpile-css-prop/output.js
@@ -15,7 +15,7 @@ function _templateObject20() {
 }
 
 function _templateObject19() {
-  var data = _taggedTemplateLiteral(["\n  font-size: 122px;\n"]);
+  var data = _taggedTemplateLiteral(["\n  font-size: 10px;\n"]);
 
   _templateObject19 = function _templateObject19() {
     return data;
@@ -25,7 +25,7 @@ function _templateObject19() {
 }
 
 function _templateObject18() {
-  var data = _taggedTemplateLiteral(["\n  color: tomato;\n"]);
+  var data = _taggedTemplateLiteral(["\n  color: red;\n"]);
 
   _templateObject18 = function _templateObject18() {
     return data;


### PR DESCRIPTION
It seems possible to do things like:

```
style1 = css``
style2 = css``

<div css={[style1, style2]} />
```

But the test for this use case is missing now.