### PR TITLE
Ensure cache miss to fix ESM compiling

### DIFF
--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -4,6 +4,7 @@ const VALID_TOP_LEVEL_IMPORT_PATHS = [
   'styled-components/native',
   'styled-components/primitives',
 ]
+const CACHE_MISS = Symbol('CACHE_MISS');
 
 export const isValidTopLevelImport = x =>
   VALID_TOP_LEVEL_IMPORT_PATHS.includes(x)
@@ -13,7 +14,7 @@ const localNameCache = {}
 export const importLocalName = (name, state, bypassCache = false) => {
   const cacheKey = name + state.file.opts.filename
 
-  if (!bypassCache && cacheKey in localNameCache) {
+  if (!bypassCache && cacheKey in localNameCache && localNameCache[cacheKey] !== CACHE_MISS) {
     return localNameCache[cacheKey]
   }
 
@@ -21,7 +22,7 @@ export const importLocalName = (name, state, bypassCache = false) => {
     ? name === 'default'
       ? 'styled'
       : name
-    : false
+    : CACHE_MISS
 
   state.file.path.traverse({
     ImportDeclaration: {


### PR DESCRIPTION
In this discussion: https://github.com/styled-components/babel-plugin-styled-components/pull/234 that introduced the change to `cacheKey in localNameCache`, the author referenced a comment you made here:
https://github.com/styled-components/babel-plugin-styled-components/pull/230#discussion_r298018008

in which, you indicated that the `false` value there was to ensure that the traversal would continue again until you either picked up the import or dynamically injected it (I think?)

When the code was changed to account for this it failed to maintain the same behavior in the case that localName was intentionally left `false`.

This change ensures that the previous behavior (allowing the intentionally set `false` to fall through the cache lookup) remains, while ensuring a `false` value in the cache does not ALSO fall through.

Pardon the lack of supporting test. The only way I was able to reproduce this issue was when I was using rollup / babel to compile. I am still investigating what this difference is specifically to hopefully introduce a failing test prior to this commit.