### PR TITLE
Support Spread Element

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -127,7 +127,8 @@ export default t => (path, state) => {
 
         acc.push(property)
       } else if (
-        // if a non-primitive value we have to interpolate it
+        // if a spread element or a non-primitive value we have to interpolate it
+        !t.isSpreadElement(property) &&
         [
           t.isBigIntLiteral,
           t.isBooleanLiteral,
@@ -151,7 +152,7 @@ export default t => (path, state) => {
 
         acc.push(t.objectProperty(property.key, t.memberExpression(p, name)))
       } else {
-        // some sort of primitive which is safe to pass through as-is
+        // spread element or some sort of primitive which is safe to pass through as-is
         acc.push(property)
       }
 

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -134,8 +134,7 @@ export default t => (path, state) => {
         )
         acc.push(property)
       } else if (
-        // if a spread element or a non-primitive value we have to interpolate it
-        !t.isSpreadElement(property) &&
+        // if a non-primitive value we have to interpolate it
         [
           t.isBigIntLiteral,
           t.isBooleanLiteral,

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -126,6 +126,13 @@ export default t => (path, state) => {
         )
 
         acc.push(property)
+      } else if (t.isSpreadElement(property)) {
+        // recurse for objects within objects (e.g. {'::before': { content: x }})
+        property.argument.properties = property.argument.properties.reduce(
+          propertiesReducer,
+          []
+        )
+        acc.push(property)
       } else if (
         // if a spread element or a non-primitive value we have to interpolate it
         !t.isSpreadElement(property) &&
@@ -152,7 +159,7 @@ export default t => (path, state) => {
 
         acc.push(t.objectProperty(property.key, t.memberExpression(p, name)))
       } else {
-        // spread element or some sort of primitive which is safe to pass through as-is
+        // some sort of primitive which is safe to pass through as-is
         acc.push(property)
       }
 

--- a/test/fixtures/transpile-css-prop-all-options-on/code.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/code.js
@@ -136,6 +136,24 @@ const ObjectPropMixedInputs = p => {
   )
 }
 
+const SpreadObjectPropMixedInputs = p => {
+  const color = 'red'
+
+  return (
+    <p
+      css={{
+        ...{ color },
+        background: p.background,
+        textAlign: 'left',
+        '::before': { content: globalVar },
+        '::after': { content: getAfterValue() },
+      }}
+    >
+      A
+    </p>
+  )
+}
+
 /* styled component defined after function it's used in */
 
 const EarlyUsageComponent = p => <Thing3 css="color: red;" />

--- a/test/fixtures/transpile-css-prop-all-options-on/code.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/code.js
@@ -142,7 +142,14 @@ const SpreadObjectPropMixedInputs = p => {
   return (
     <p
       css={{
-        ...{ color },
+        ...{
+          '::before': { content: globalVar },
+          '::after': { content: getAfterValue() },
+          ...{
+            '::before': { content: globalVar },
+            '::after': { content: getAfterValue() },
+          },
+        },
         background: p.background,
         textAlign: 'left',
         '::before': { content: globalVar },

--- a/test/fixtures/transpile-css-prop-all-options-on/output.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/output.js
@@ -6,6 +6,12 @@ var _SomeComponentPath = _interopRequireDefault(require("../SomeComponentPath"))
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 var _require = require('../SomeOtherComponentPath'),
     SomeOtherComponent = _require.SomeOtherComponent;
 /**
@@ -236,6 +242,31 @@ var ObjectPropMixedInputs = function ObjectPropMixedInputs(p) {
       A
     </_StyledP12>;
 };
+
+var _StyledP13 = (0, _styledComponents["default"])("p").withConfig({
+  displayName: "code___StyledP13",
+  componentId: "sc-7evkve-20"
+})(function (p) {
+  return _objectSpread({}, {
+    color: color
+  }, {
+    background: p._css8,
+    textAlign: 'left',
+    '::before': {
+      content: p._css9
+    },
+    '::after': {
+      content: p._css10
+    }
+  });
+});
+
+var SpreadObjectPropMixedInputs = function SpreadObjectPropMixedInputs(p) {
+  var color = 'red';
+  return <_StyledP13 _css8={p.background} _css9={globalVar} _css10={getAfterValue()}>
+      A
+    </_StyledP13>;
+};
 /* styled component defined after function it's used in */
 
 
@@ -245,12 +276,12 @@ var EarlyUsageComponent = function EarlyUsageComponent(p) {
 
 var Thing3 = _styledComponents["default"].div.withConfig({
   displayName: "code__Thing3",
-  componentId: "sc-7evkve-20"
+  componentId: "sc-7evkve-21"
 })(["color:blue;"]);
 
 var _StyledThing = (0, _styledComponents["default"])(Thing3).withConfig({
   displayName: "code___StyledThing",
-  componentId: "sc-7evkve-21"
+  componentId: "sc-7evkve-22"
 })(["color:red;"]);
 
 var EarlyUsageComponent2 = function EarlyUsageComponent2(p) {
@@ -265,12 +296,12 @@ function Thing4(props) {
 
 var _StyledThing2 = (0, _styledComponents["default"])(Thing4).withConfig({
   displayName: "code___StyledThing2",
-  componentId: "sc-7evkve-22"
+  componentId: "sc-7evkve-23"
 })(["color:red;"]);
 
 var _StyledSomeComponent = (0, _styledComponents["default"])(_SomeComponentPath["default"]).withConfig({
   displayName: "code___StyledSomeComponent",
-  componentId: "sc-7evkve-23"
+  componentId: "sc-7evkve-24"
 })(["color:red;"]);
 
 var ImportedComponentUsage = function ImportedComponentUsage(p) {

--- a/test/fixtures/transpile-css-prop-all-options-on/output.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/output.js
@@ -247,23 +247,35 @@ var _StyledP13 = (0, _styledComponents["default"])("p").withConfig({
   displayName: "code___StyledP13",
   componentId: "sc-7evkve-20"
 })(function (p) {
-  return _objectSpread({}, {
-    color: color
-  }, {
-    background: p._css8,
-    textAlign: 'left',
+  return _objectSpread({}, _objectSpread({
     '::before': {
-      content: p._css9
+      content: p._css8
     },
     '::after': {
+      content: p._css9
+    }
+  }, {
+    '::before': {
       content: p._css10
+    },
+    '::after': {
+      content: p._css11
+    }
+  }), {
+    background: p._css12,
+    textAlign: 'left',
+    '::before': {
+      content: p._css13
+    },
+    '::after': {
+      content: p._css14
     }
   });
 });
 
 var SpreadObjectPropMixedInputs = function SpreadObjectPropMixedInputs(p) {
   var color = 'red';
-  return <_StyledP13 _css8={p.background} _css9={globalVar} _css10={getAfterValue()}>
+  return <_StyledP13 _css8={globalVar} _css9={getAfterValue()} _css10={globalVar} _css11={getAfterValue()} _css12={p.background} _css13={globalVar} _css14={getAfterValue()}>
       A
     </_StyledP13>;
 };


### PR DESCRIPTION
**Background**
Spread operator does not work. See the following issue for more details: https://github.com/styled-components/babel-plugin-styled-components/issues/235.

This fails as the transpiler tries to convert the SpreadElement node into a key/value. Additionally, it needs to ensure that objects are converted into a p

**Change**
* Do not treat spreadElement as an expression
* Properly map object values of the SpreadElement argument into Styled component props.

**Test Plan**
Added a new test case that validates spread elements and nested spread elements are handled properly. The gen code looks correct, but I'm not too familiar with what styled components gen code should look like. 