### PR TITLE
Support styled as a named export

### DIFF
--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -34,6 +34,10 @@ export const importLocalName = (name, state, bypassCache = false) => {
 
         if (isValidTopLevelImport(node.source.value, state)) {
           for (const specifier of path.get('specifiers')) {
+            if (specifier.isImportSpecifier() && specifier.node.imported.name === 'styled') {
+              localName = 'styled'
+            }
+            
             if (specifier.isImportDefaultSpecifier()) {
               localName = specifier.node.local.name
             }

--- a/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/.babelrc
+++ b/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/.babelrc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "displayName": true,
+        "fileName": false,
+        "ssr": true,
+        "topLevelImportPaths": ["@example/example"],
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/code.js
+++ b/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/code.js
@@ -1,0 +1,10 @@
+import { styled } from '@example/example'
+
+const Test = styled.div`
+  width: 100%;
+`
+const Test2 = true ? styled.div`` : styled.div``
+const styles = { One: styled.div`` }
+let Component
+Component = styled.div``
+const WrappedComponent = styled(Inner)``

--- a/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/output.js
+++ b/test/fixtures/add-identifier-with-top-level-import-paths-and-named-import/output.js
@@ -1,0 +1,27 @@
+import { styled } from '@example/example';
+const Test = styled.div.withConfig({
+  displayName: "Test",
+  componentId: "elhbfv-0"
+})`width:100%;`;
+const Test2 = true ? styled.div.withConfig({
+  displayName: "Test2",
+  componentId: "elhbfv-1"
+})`` : styled.div.withConfig({
+  displayName: "Test2",
+  componentId: "elhbfv-2"
+})``;
+const styles = {
+  One: styled.div.withConfig({
+    displayName: "One",
+    componentId: "elhbfv-3"
+  })``
+};
+let Component;
+Component = styled.div.withConfig({
+  displayName: "Component",
+  componentId: "elhbfv-4"
+})``;
+const WrappedComponent = styled(Inner).withConfig({
+  displayName: "WrappedComponent",
+  componentId: "elhbfv-5"
+})``;


### PR DESCRIPTION
To support the upcoming `topLevelImportPaths` option, this allows this babel plugin to pick-up `styled` as a named export:

```js
import { styled } from '@wrapping/package'`
```

config:

```
[
  'styled-components',
  {
    topLevelImportPaths: ['@wrapping/package'],
  },
]
```