### PR TITLE
preserve structure of JSX member expressions in generated ast nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/preset-env": "^7.4.5",
     "babel-core": "7.0.0-bridge.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",

--- a/test/fixtures/transformed-imports-with-jsx-member-expressions/.babelrc
+++ b/test/fixtures/transformed-imports-with-jsx-member-expressions/.babelrc
@@ -1,0 +1,8 @@
+{
+    "plugins": [
+      ["@babel/plugin-transform-modules-commonjs"],
+      [
+        "../../../src"
+      ]
+    ]
+  }

--- a/test/fixtures/transformed-imports-with-jsx-member-expressions/code.js
+++ b/test/fixtures/transformed-imports-with-jsx-member-expressions/code.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { css } from "styled-components";
+import Icons from "./icons";
+
+const someCss = css` background: purple;`;
+
+const App1 = () => { return <Icons css={someCss} />; };
+
+const App2 = () => { return <Icons.Foo css={someCss} />; };
+
+const App3 = () => { return <Icons.Foo.Bar css={someCss} />; };

--- a/test/fixtures/transformed-imports-with-jsx-member-expressions/output.js
+++ b/test/fixtures/transformed-imports-with-jsx-member-expressions/output.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var _styledComponents = _interopRequireWildcard(require("styled-components"));
+
+var _react = _interopRequireDefault(require("react"));
+
+var _icons = _interopRequireDefault(require("./icons"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+const someCss = (0, _styledComponents.css)([" background:purple;"]);
+
+var _StyledIcons = (0, _styledComponents.default)(_icons.default).withConfig({
+  displayName: "code___StyledIcons",
+  componentId: "sc-1wxehft-0"
+})(["", ""], someCss);
+
+const App1 = () => {
+  return <_StyledIcons />;
+};
+
+var _StyledIconsFoo = (0, _styledComponents.default)(_icons.default.Foo).withConfig({
+  displayName: "code___StyledIconsFoo",
+  componentId: "sc-1wxehft-1"
+})(["", ""], someCss);
+
+const App2 = () => {
+  return <_StyledIconsFoo />;
+};
+
+var _StyledIconsFooBar = (0, _styledComponents.default)(_icons.default.Foo.Bar).withConfig({
+  displayName: "code___StyledIconsFooBar",
+  componentId: "sc-1wxehft-2"
+})(["", ""], someCss);
+
+const App3 = () => {
+  return <_StyledIconsFooBar />;
+};


### PR DESCRIPTION
this makes sure that other babel transformations that rename variables will be able to process the ast nodes created by this plugin

fixes #240