### PR TITLE
Recurse only when the argument of Spread Element is object expression

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -127,11 +127,13 @@ export default t => (path, state) => {
 
         acc.push(property)
       } else if (t.isSpreadElement(property)) {
-        // recurse for objects within objects (e.g. {'::before': { content: x }})
-        property.argument.properties = property.argument.properties.reduce(
-          propertiesReducer,
-          []
-        )
+        if (t.isObjectExpression(property.argument)) {
+          // recurse for objects within objects (e.g. {'::before': { content: x }})
+          property.argument.properties = property.argument.properties.reduce(
+            propertiesReducer,
+            []
+          )
+        }
         acc.push(property)
       } else if (
         // if a non-primitive value we have to interpolate it

--- a/test/fixtures/transpile-css-prop-all-options-on/code.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/code.js
@@ -161,6 +161,23 @@ const SpreadObjectPropMixedInputs = p => {
   )
 }
 
+const SpreadObjectInputs = p => {
+  const cssObj = { background: 'red' }
+
+  return (
+    <p
+      css={{
+        ...cssObj,
+        textAlign: 'left',
+        '::before': { content: globalVar },
+        '::after': { content: getAfterValue() },
+      }}
+    >
+      A
+    </p>
+  )
+}
+
 /* styled component defined after function it's used in */
 
 const EarlyUsageComponent = p => <Thing3 css="color: red;" />

--- a/test/fixtures/transpile-css-prop-all-options-on/output.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/output.js
@@ -279,6 +279,30 @@ var SpreadObjectPropMixedInputs = function SpreadObjectPropMixedInputs(p) {
       A
     </_StyledP13>;
 };
+
+var _StyledP14 = (0, _styledComponents["default"])("p").withConfig({
+  displayName: "code___StyledP14",
+  componentId: "sc-7evkve-21"
+})(function (p) {
+  return _objectSpread(_objectSpread({}, cssObj), {}, {
+    textAlign: 'left',
+    '::before': {
+      content: p._css15
+    },
+    '::after': {
+      content: p._css16
+    }
+  });
+});
+
+var SpreadObjectInputs = function SpreadObjectInputs(p) {
+  var cssObj = {
+    background: 'red'
+  };
+  return <_StyledP14 _css15={globalVar} _css16={getAfterValue()}>
+      A
+    </_StyledP14>;
+};
 /* styled component defined after function it's used in */
 
 
@@ -288,12 +312,12 @@ var EarlyUsageComponent = function EarlyUsageComponent(p) {
 
 var Thing3 = _styledComponents["default"].div.withConfig({
   displayName: "code__Thing3",
-  componentId: "sc-7evkve-21"
+  componentId: "sc-7evkve-22"
 })(["color:blue;"]);
 
 var _StyledThing = (0, _styledComponents["default"])(Thing3).withConfig({
   displayName: "code___StyledThing",
-  componentId: "sc-7evkve-22"
+  componentId: "sc-7evkve-23"
 })(["color:red;"]);
 
 var EarlyUsageComponent2 = function EarlyUsageComponent2(p) {
@@ -308,12 +332,12 @@ function Thing4(props) {
 
 var _StyledThing2 = (0, _styledComponents["default"])(Thing4).withConfig({
   displayName: "code___StyledThing2",
-  componentId: "sc-7evkve-23"
+  componentId: "sc-7evkve-24"
 })(["color:red;"]);
 
 var _StyledSomeComponent = (0, _styledComponents["default"])(_SomeComponentPath["default"]).withConfig({
   displayName: "code___StyledSomeComponent",
-  componentId: "sc-7evkve-24"
+  componentId: "sc-7evkve-25"
 })(["color:red;"]);
 
 var ImportedComponentUsage = function ImportedComponentUsage(p) {


### PR DESCRIPTION
Using Spread syntax in css prop is currently supported, but this syntax is not supported.
```js
<div
  css={{
    ...obj,
    { color: 'red' }
  }}
>
  hi
</div>
```

it causes the error that can not read property `reduce` because it has not `property.argument.properties`

This PR resolves it by recursing only when the argument of Spread Element is object expression.