### PR TITLE
Revert "Recurse only when the argument of Spread Element is object expression"

### DIFF
--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -127,13 +127,11 @@ export default t => (path, state) => {
 
         acc.push(property)
       } else if (t.isSpreadElement(property)) {
-        if (t.isObjectExpression(property.argument)) {
-          // recurse for objects within objects (e.g. {'::before': { content: x }})
-          property.argument.properties = property.argument.properties.reduce(
-            propertiesReducer,
-            []
-          )
-        }
+        // recurse for objects within objects (e.g. {'::before': { content: x }})
+        property.argument.properties = property.argument.properties.reduce(
+          propertiesReducer,
+          []
+        )
         acc.push(property)
       } else if (
         // if a non-primitive value we have to interpolate it

--- a/test/fixtures/transpile-css-prop-all-options-on/code.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/code.js
@@ -161,23 +161,6 @@ const SpreadObjectPropMixedInputs = p => {
   )
 }
 
-const SpreadObjectInputs = p => {
-  const cssObj = { background: 'red' }
-
-  return (
-    <p
-      css={{
-        ...cssObj,
-        textAlign: 'left',
-        '::before': { content: globalVar },
-        '::after': { content: getAfterValue() },
-      }}
-    >
-      A
-    </p>
-  )
-}
-
 /* styled component defined after function it's used in */
 
 const EarlyUsageComponent = p => <Thing3 css="color: red;" />

--- a/test/fixtures/transpile-css-prop-all-options-on/output.js
+++ b/test/fixtures/transpile-css-prop-all-options-on/output.js
@@ -279,30 +279,6 @@ var SpreadObjectPropMixedInputs = function SpreadObjectPropMixedInputs(p) {
       A
     </_StyledP13>;
 };
-
-var _StyledP14 = (0, _styledComponents["default"])("p").withConfig({
-  displayName: "code___StyledP14",
-  componentId: "sc-7evkve-21"
-})(function (p) {
-  return _objectSpread(_objectSpread({}, cssObj), {}, {
-    textAlign: 'left',
-    '::before': {
-      content: p._css15
-    },
-    '::after': {
-      content: p._css16
-    }
-  });
-});
-
-var SpreadObjectInputs = function SpreadObjectInputs(p) {
-  var cssObj = {
-    background: 'red'
-  };
-  return <_StyledP14 _css15={globalVar} _css16={getAfterValue()}>
-      A
-    </_StyledP14>;
-};
 /* styled component defined after function it's used in */
 
 
@@ -312,12 +288,12 @@ var EarlyUsageComponent = function EarlyUsageComponent(p) {
 
 var Thing3 = _styledComponents["default"].div.withConfig({
   displayName: "code__Thing3",
-  componentId: "sc-7evkve-22"
+  componentId: "sc-7evkve-21"
 })(["color:blue;"]);
 
 var _StyledThing = (0, _styledComponents["default"])(Thing3).withConfig({
   displayName: "code___StyledThing",
-  componentId: "sc-7evkve-23"
+  componentId: "sc-7evkve-22"
 })(["color:red;"]);
 
 var EarlyUsageComponent2 = function EarlyUsageComponent2(p) {
@@ -332,12 +308,12 @@ function Thing4(props) {
 
 var _StyledThing2 = (0, _styledComponents["default"])(Thing4).withConfig({
   displayName: "code___StyledThing2",
-  componentId: "sc-7evkve-24"
+  componentId: "sc-7evkve-23"
 })(["color:red;"]);
 
 var _StyledSomeComponent = (0, _styledComponents["default"])(_SomeComponentPath["default"]).withConfig({
   displayName: "code___StyledSomeComponent",
-  componentId: "sc-7evkve-25"
+  componentId: "sc-7evkve-24"
 })(["color:red;"]);
 
 var ImportedComponentUsage = function ImportedComponentUsage(p) {


### PR DESCRIPTION
Sorry, there was a problem with the PR I created. (#301)
I noticed `cssObj ` needs to be injected via props.
https://github.com/styled-components/babel-plugin-styled-components/blob/2580a0597e383f7b49ec48c322ca6ac00ae19556/test/fixtures/transpile-css-prop-all-options-on/output.js#L283-L287

I tested it in my project in advance, but at that time I didn't notice that because webpack inserted the styles that were imported from another file.
I'll recreate the PR with some fixes.