### PR TITLE
merge existing withConfig arguments to allow SSR when using shouldForwardProp

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
 }

--- a/test/fixtures/add-identifier-and-display-name/code.js
+++ b/test/fixtures/add-identifier-and-display-name/code.js
@@ -13,3 +13,18 @@ const WrappedComponent3 = styled(Inner)({})
 const WrappedComponent4 = styled(Inner).attrs(() => ({ something: 'else' }))({})
 const WrappedComponent5 = styled.div.attrs(() => ({ something: 'else' }))({})
 const WrappedComponent6 = styled.div.attrs(() => ({ something: 'else' }))``
+const WrappedComponent7 = styled.div.withConfig({
+  shouldForwardProp: () => {},
+})({})
+
+const WrappedComponent8 = styled.div
+  .withConfig({
+    shouldForwardProp: () => {},
+  })
+  .attrs(() => ({ something: 'else' }))({})
+
+const WrappedComponent9 = styled.div
+  .attrs(() => ({ something: 'else' }))
+  .withConfig({
+    shouldForwardProp: () => {},
+  })({})

--- a/test/fixtures/add-identifier-and-display-name/output.js
+++ b/test/fixtures/add-identifier-and-display-name/output.js
@@ -51,3 +51,22 @@ const WrappedComponent6 = styled.div.attrs(() => ({
   displayName: "WrappedComponent6",
   componentId: "sc-1cza72q-10"
 })``;
+const WrappedComponent7 = styled.div.withConfig({
+  shouldForwardProp: () => {},
+  displayName: "WrappedComponent7",
+  componentId: "sc-1cza72q-11"
+})({});
+const WrappedComponent8 = styled.div.withConfig({
+  shouldForwardProp: () => {},
+  displayName: "WrappedComponent8",
+  componentId: "sc-1cza72q-12"
+}).attrs(() => ({
+  something: 'else'
+}))({});
+const WrappedComponent9 = styled.div.attrs(() => ({
+  something: 'else'
+})).withConfig({
+  shouldForwardProp: () => {},
+  displayName: "WrappedComponent9",
+  componentId: "sc-1cza72q-13"
+})({});


### PR DESCRIPTION
Resolves issue #322 where if you have an existing withConfig on your component in order to leverage shouldForwardProp babel was not adding a displayName or componentId

this takes the existing expression adds the additional args and replaces the existing withConfig