### PR TITLE
Resolve operability issue with rollup

### DIFF
--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -14,8 +14,10 @@ export const isValidTopLevelImport = (x, state) =>
 
 const localNameCache = {}
 
-export const importLocalName = (name, state, bypassCache = false) => {
-  const cacheKey = name + state.file.opts.filename
+export const importLocalName = (name, state, options = {}) => {
+  const { cacheIdentifier, bypassCache = false } = options;
+  const cacheKeyAffix = cacheIdentifier ? `|${cacheIdentifier}` : '';
+  const cacheKey = name + state.file.opts.filename + cacheKeyAffix;
 
   if (!bypassCache && cacheKey in localNameCache) {
     return localNameCache[cacheKey]
@@ -74,9 +76,9 @@ export const isStyled = t => (tag, state) => {
   } else {
     return (
       (t.isMemberExpression(tag) &&
-        tag.object.name === importLocalName('default', state)) ||
+        tag.object.name === importLocalName('default', state, { cacheIdentifier: tag.object.name })) ||
       (t.isCallExpression(tag) &&
-        tag.callee.name === importLocalName('default', state)) ||
+        tag.callee.name === importLocalName('default', state, { cacheIdentifier: tag.callee.name })) ||
       /**
        * #93 Support require()
        * styled-components might be imported using a require()

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -44,7 +44,7 @@ export default t => (path, state) => {
       nameHint: 'styled',
     })
 
-    importName = t.identifier(importLocalName('default', state, true))
+    importName = t.identifier(importLocalName('default', state, { bypassCache: true }))
   }
 
   if (!t.isIdentifier(importName)) importName = t.identifier(importName)


### PR DESCRIPTION
When using `rollup` to bundle, all versions after `1.10.5` fail to generate a `withConfig` for styled components.

## Context
Reported issue [here](https://github.com/styled-components/babel-plugin-styled-components/issues/280).
Changes between versions: https://github.com/styled-components/babel-plugin-styled-components/compare/v1.10.5...v1.10.6

The breaking (but correct) change in `v1.10.6`:
```typescript
if (!bypassCache && cacheKey in localNameCache) {
  return localNameCache[cacheKey]
}
```

This change was necessary to utilize the cache and exit early:
```typescript
const localNameCache = {};

// First pass, cacheKey = 'first'
localNameCache[cacheKey]; // -> undefined
cacheKey in localNameCache; // -> false

// Second pass, cacheKey = 'first'
localNameCache[cacheKey]; // -> false
cacheKey in localNameCache; // -> true
```

Prior to `v1.10.6`,  the plugin would traverse the AST each time until a `localName` has been specified. Particularly, the code'll ignore previously stored `false` cache values.

## Investigation
As suggested in https://github.com/styled-components/babel-plugin-styled-components/issues/280#issuecomment-620301036, `rollup` will generate an AST from the provided source files. Not to go into too much detail, `rollup` appears to prepend some additional nodes to the AST.

I uploaded a gist that logs out each AST node that's considered by this plugin https://gist.github.com/ktranada/edad40fe3c01342eb6ededc3f2a4f669

suppose the following:
```typescript
// Box/index.tsx
import styled from 'styled-components'; // <- represented as an `MemberExpression ` node in the AST
export const Box = styled.div``;
```

When only using `babel` to transpile the code: 
- AST is generated
- Traverse the AST + parse nodes as described
  - The one and only `MemberExpression ` satisfies the requirements
  - the result is stored in the cache, using the filename as the cache key

When using `rollup` to bundle the code,
- Rollup generates its own AST of the source files
  - It may prepend nodes to the AST (these may or may not be present in the generated output)
- Traverse the AST
  - If rollup (or any bundler) prepends nodes to the AST and these nodes are parsed before the target `MemberExpression` node, the result is stored for the file and used for **all** subsequent lookups in this file -- this will cause the program to exit early with the stored result when parsing the target `MemberExpression` node.
  - In the gist above, you can see that there are multiple nodes to consider before reaching the node (line 155 of the gist) representing the `styled` import.

## Solution
The change introduced in `v1.10.6` is needed and should stay. 
We want to avoid repeatedly traversing the AST for known nodes and instead leverage the cached result.
We can augment the cache key with the name of the node that's being parsed. 