### PR TITLE
Custom prefix added, if none set will fallback to `sc-`

### DIFF
--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -21,6 +21,14 @@ export const useNamespace = state => {
   return ''
 }
 
+export const usePrefix = state => {
+  const prefix = getOption(state, 'prefix', '')
+  if (prefix) {
+    return `${prefix}`
+  }
+  return 'sc'
+}
+
 export const usePureAnnotation = state => getOption(state, 'pure', false)
 
 export const useCssProp = state => getOption(state, 'cssProp', true)

--- a/src/visitors/displayNameAndId.js
+++ b/src/visitors/displayNameAndId.js
@@ -5,6 +5,7 @@ import {
   useDisplayName,
   useSSR,
   useNamespace,
+  usePrefix,
 } from '../utils/options'
 import getName from '../utils/getName'
 import prefixLeadingDigit from '../utils/prefixDigit'
@@ -193,7 +194,7 @@ const getNextId = state => {
 
 const getComponentId = state => {
   // Prefix the identifier with a character because CSS classes cannot start with a number
-  return `${useNamespace(state)}sc-${getFileHash(state)}-${getNextId(state)}`
+  return `${useNamespace(state)}${usePrefix(state)}-${getFileHash(state)}-${getNextId(state)}`
 }
 
 export default t => (path, state) => {


### PR DESCRIPTION
I've been looking for a while to change the `sc` prefix to a custom value.
The setting for `prefix` is read from the json config, much like `namespace`.