### PR TITLE
Add failing test case

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+test/fixtures

--- a/test/fixtures/mui/.babelrc
+++ b/test/fixtures/mui/.babelrc
@@ -1,0 +1,19 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "fileName": false,
+        "transpileTemplateLiterals": false,
+        "ssr": true,
+        "topLevelImportPaths": [
+          "@mui/material",
+          "@mui/material/*",
+          "@mui/system",
+          "@mui/styled-engine-sc"
+        ]
+      }
+    ],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/test/fixtures/mui/code.js
+++ b/test/fixtures/mui/code.js
@@ -1,0 +1,9 @@
+import { styled as matStyled } from '@mui/material/styles'
+import sc from '@mui/material/styles'
+
+const Test1 = matStyled('div')({
+  width: '100%',
+})
+const Test2 = sc('div')({
+  width: '100%',
+})

--- a/test/fixtures/mui/output.js
+++ b/test/fixtures/mui/output.js
@@ -1,0 +1,14 @@
+import { styled as matStyled } from '@mui/material/styles';
+import sc from '@mui/material/styles';
+const Test1 = matStyled('div').withConfig({
+  displayName: 'Test1',
+  componentId: 'sc-2jen0y-0',
+})({
+  width: '100%'
+});
+const Test2 = sc('div').withConfig({
+  displayName: 'Test2',
+  componentId: 'sc-2jen0y-1',
+})({
+  width: '100%'
+});


### PR DESCRIPTION
Ran into this while debugging another problem. `babel-plugin-styled-components` doesn't recognise these imports:
```tsx
import { styled as matStyled } from '@mui/material/styles'
```