### PR TITLE
Doesn't work on the MUI commonjs modules

### DIFF
--- a/test/fixtures/compiled/.babelrc
+++ b/test/fixtures/compiled/.babelrc
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "fileName": false,
+        "transpileTemplateLiterals": false,
+        "ssr": true
+      }
+    ],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/test/fixtures/compiled/code.js
+++ b/test/fixtures/compiled/code.js
@@ -1,0 +1,5 @@
+var _styled = _interopRequireDefault(require("styled-components"));
+
+const Test = (0, _styled.default)('div')({
+  width: '100%',
+});

--- a/test/fixtures/compiled/output.js
+++ b/test/fixtures/compiled/output.js
@@ -1,0 +1,8 @@
+var _styled = _interopRequireDefault(require("styled-components"));
+
+const Test = (0, _styled.default)('div').withConfig({
+  displayName: 'Test',
+  componentId: 'sc-2jen0y-0',
+})({
+  width: '100%'
+});


### PR DESCRIPTION
I'm currently investigating an issue on `@mui/material`+`styled-components`+`next` (https://github.com/mui-org/material-ui/issues/29742). It turns that in the Next.js server bundle, the `styled` calls are not correctly being identified by `babel-plugin-styled-components`. The server bundle uses the commonjs version of `@mui/material`. This PR adds a failing test case for that format.

_edit: 🤔  The new test doesn't seem to run in CI for some reason_