### PR TITLE
fix: pattern match of topLevelImportPaths was unanchored

### DIFF
--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -6,7 +6,7 @@ function getOption({ opts }, name, defaultValue = true) {
 
 export const useDisplayName = state => getOption(state, 'displayName')
 export const useTopLevelImportPathMatchers = state =>
-  getOption(state, 'topLevelImportPaths', []).map(pattern => new RegExp(pattern))
+  getOption(state, 'topLevelImportPaths', []).map(pattern => new RegExp(`^${pattern}$`))
 export const useSSR = state => getOption(state, 'ssr', true)
 export const useFileName = state => getOption(state, 'fileName')
 export const useMeaninglessFileNames = state => getOption(state, 'meaninglessFileNames', ['index'])

--- a/test/fixtures/add-identifier-with-top-level-import-paths/.babelrc
+++ b/test/fixtures/add-identifier-with-top-level-import-paths/.babelrc
@@ -8,7 +8,7 @@
         "ssr": true,
         "topLevelImportPaths": [
           "@xstyled/styled-components",
-          "@xstyled/styled-components/*"
+          "@xstyled/styled-components/.*"
         ],
         "transpileTemplateLiterals": false
       }


### PR DESCRIPTION
This seems to have been a mistake in #354

It _might_ fix https://github.com/styled-components/styled-components/issues/3635 but that's somewhat involved to test while this is unreleased, so it might be easier to make this release and find out.