### PR TITLE
fix minifier bug #366

### DIFF
--- a/src/minify/index.js
+++ b/src/minify/index.js
@@ -64,13 +64,18 @@ export const compressSymbols = code =>
 
     // Only manipulate symbols outside of strings
     if (
-      countOccurences(str, "'") % 2 === 0 &&
-      countOccurences(str, '"') % 2 === 0
+      countOccurences(str, "'") % 2 !== 0 ||
+      countOccurences(str, '"') % 2 !== 0
     ) {
-      return str + fragment.trim()
+      return str + fragment
     }
 
-    return str + fragment
+    // Preserve whitespace preceding colon, to avoid joining selectors.
+    if (/^\s+:/.test(fragment)) {
+      return str + ' ' + fragment.trim()
+    }
+
+    return str + fragment.trim()
   }, '')
 
 // Detects lines that are exclusively line comments

--- a/test/minify/index.test.js
+++ b/test/minify/index.test.js
@@ -113,6 +113,9 @@ describe('minify utils', () => {
 
   describe('compressSymbols', () => {
     it('removes spaces around symbols', () => {
+      // The whitespace preceding the colon is removed here as part of the
+      // trailing whitespace on the semi-colon. Contrast to the "preserves"
+      // test below.
       const input = ';  :  {  }  ,  ;  '
       const expected = ';:{},;'
 
@@ -122,6 +125,13 @@ describe('minify utils', () => {
     it('ignores symbols inside strings', () => {
       const input = ';   " : " \' : \' ;'
       const expected = ';" : " \' : \';'
+
+      expect(compressSymbols(input)).toBe(expected)
+    })
+
+    it('preserves whitespace preceding colons', () => {
+      const input = '& :last-child { color: blue; }'
+      const expected = '& :last-child{color:blue;}'
 
       expect(compressSymbols(input)).toBe(expected)
     })


### PR DESCRIPTION
The minifier doesn't distinguish between selectors and rules, so we preserve any whitespace separator preceding a colon.