### PR TITLE
updated lodash from 4.17.11 to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/helper-annotate-as-pure": "^7.16.0",
     "@babel/helper-module-imports": "^7.16.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.21",
     "picomatch": "^2.3.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,7 +3135,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash@^4.17.11, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4.17.11, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Hi! 👋
This PR updates the version of lodash to fix https://github.com/advisories/GHSA-p6mc-m468-83gw.
The tests seem to pass, let me know if you need anything else!