### PR TITLE
Support pre-transpiled code (#379)

### DIFF
--- a/src/utils/getSequenceExpressionValue.js
+++ b/src/utils/getSequenceExpressionValue.js
@@ -1,0 +1,4 @@
+export default path =>
+  path.expressions && path.expressions.length
+    ? path.expressions[path.expressions.length - 1]
+    : undefined

--- a/src/visitors/assignStyledRequired.js
+++ b/src/visitors/assignStyledRequired.js
@@ -1,14 +1,27 @@
 import { isValidTopLevelImport } from '../utils/detectors'
 
 export default t => (path, state) => {
+  let init = path.node.init;
+
   if (
     t.isCallExpression(path.node.init) &&
     t.isIdentifier(path.node.init.callee) &&
-    path.node.init.callee.name === 'require' &&
-    path.node.init.arguments &&
-    path.node.init.arguments[0] &&
-    t.isLiteral(path.node.init.arguments[0]) &&
-    isValidTopLevelImport(path.node.init.arguments[0].value, state)
+    init.callee.name === '_interopRequireDefault' &&
+    init.arguments &&
+    init.arguments[0]
+  ) {
+    // _interopRequireDefault(require())
+    init = path.node.init.arguments[0];
+  }
+
+  if (
+    t.isCallExpression(init) &&
+    t.isIdentifier(init.callee) &&
+    init.callee.name === 'require' &&
+    init.arguments &&
+    init.arguments[0] &&
+    t.isLiteral(init.arguments[0]) &&
+    isValidTopLevelImport(init.arguments[0].value, state)
   ) {
     state.styledRequired = path.node.id.name
   }

--- a/test/fixtures/pre-transpiled/.babelrc
+++ b/test/fixtures/pre-transpiled/.babelrc
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "fileName": false,
+        "transpileTemplateLiterals": false,
+        "ssr": true
+      }
+    ],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ]
+}

--- a/test/fixtures/pre-transpiled/code.js
+++ b/test/fixtures/pre-transpiled/code.js
@@ -1,0 +1,5 @@
+var _styled = _interopRequireDefault(require("styled-components"));
+
+const Test = (0, _styled.default)('div')({
+  width: '100%',
+});

--- a/test/fixtures/pre-transpiled/output.js
+++ b/test/fixtures/pre-transpiled/output.js
@@ -1,0 +1,8 @@
+var _styled = _interopRequireDefault(require("styled-components"));
+
+const Test = (0, _styled.default)('div').withConfig({
+  displayName: "Test",
+  componentId: "sc-1m3e07f-0"
+})({
+  width: '100%'
+});


### PR DESCRIPTION
This adds support for identifying styled components imports using `_interopRequiredDefault` and calls to styled components that use sequence expressions (ex. `(0, _styled)('div')()`).

This should improve support for MUI + Next with SSR.

In `isStyled`, I added equivalent checks for sequence expressions wherever they could be used instead of member expressions. However, there's one case that I'm not sure will ever apply:

```js
(importLocalName('default', state) &&
  t.isCallExpression(tag) &&
  t.isMemberExpression(tag.callee) &&
  tag.object.property.name === 'default' &&
  tag.object.object.name === importLocalName('default', state))
```
  
Please let me know if this needs an equivalent sequence expression check.
  
I thought maybe this PR might add some new errors on re-transpilation, but I ran tests using outputs as inputs and didn't see any new problems.