### PR TITLE
When testing import paths, only use string literals.

### DIFF
--- a/src/visitors/assignStyledRequired.js
+++ b/src/visitors/assignStyledRequired.js
@@ -20,7 +20,7 @@ export default t => (path, state) => {
     init.callee.name === 'require' &&
     init.arguments &&
     init.arguments[0] &&
-    t.isLiteral(init.arguments[0]) &&
+    t.isStringLiteral(init.arguments[0]) &&
     isValidTopLevelImport(init.arguments[0].value, state)
   ) {
     state.styledRequired = path.node.id.name


### PR DESCRIPTION
Prior to this change, code with template literals inside of `require` calls would break. This is because the check of `t.isLiteral` is far too broad for this usage, and assumes that all literals have a `value` property. Since `TemplateLiteral` nodes do not, they would cause `picomatch` to fail on an `undefined` input.