### PR TITLE
Fix css-prop transform bugs and modernize toolchain

### DIFF
--- a/.changeset/modernize-dependencies.md
+++ b/.changeset/modernize-dependencies.md
@@ -2,11 +2,12 @@
 "babel-plugin-styled-components": minor
 ---
 
-Refresh the toolchain and fix a handful of css-prop transform bugs that had crept in under recent Babel versions.
+Refresh the dev toolchain and fix a handful of css-prop transform bugs.
 
-- When a file already imports `styled` and also uses one or more `css={…}` props, every styled component now keeps its display name and stable component id. Previously the cache that tracks the local default import could be overwritten on each css-prop usage, which silently dropped the display name and id for the surrounding `styled.div` declarations.
-- `css={{ [foo]: bar }}` with a non-primitive value no longer fails Babel's validator. Computed keys are preserved through the css-prop object rewrite.
-- Friendlier error messages when the css-prop transform encounters a JSX name shape it can't infer, instead of a confusing internal `ReferenceError`.
-- Long-running watch processes (Next dev, webpack-dev-server, jest watch) no longer leak import-detection state between files.
-- Removed the runtime `lodash` dependency. The plugin now ships with `@babel/core` as a declared peer.
-- Dev tooling moved to pnpm and changesets. Plugin behavior is unchanged.
+- Files mixing regular styled components with `css={...}` props keep their display names and component ids again.
+- `css={{ [foo]: bar }}` with a non-primitive value no longer crashes the build.
+- `withConfig({ ...spread })` and `withConfig({ 'displayName': '...' })` no longer crash or silently override your explicit values.
+- Errors from the css-prop transform now point at the offending source line.
+- Long-running dev servers no longer leak detection state between files.
+- Drops the `lodash` runtime dependency. `@babel/core` is now a declared peer.
+- Dev tooling moved to pnpm and changesets.


### PR DESCRIPTION
## Summary
This PR fixes several bugs in the babel-plugin-styled-components css-prop transform and modernizes the development toolchain. The plugin now correctly handles edge cases when mixing styled components with css props, computed property keys, and config spreading.

## Key Changes
- **Display name preservation**: Fixed cache invalidation bug where styled components lost their display names and component IDs when files used both `styled` imports and `css={...}` props
- **Computed property keys**: `css={{ [foo]: bar }}` expressions with non-primitive values now pass Babel validation instead of crashing
- **Config spreading**: `withConfig()` calls with spread operators or explicit property names no longer crash or silently override user values
- **Error reporting**: css-prop transform errors now point to the actual source line instead of generic internal errors
- **State leakage fix**: Long-running dev servers (Next.js dev, webpack-dev-server, jest watch) no longer leak import-detection state between file transformations
- **Dependency cleanup**: Removed runtime `lodash` dependency; `@babel/core` is now a declared peer dependency
- **Tooling**: Migrated dev tooling to pnpm and changesets for better dependency management

## Notes
Plugin behavior and public API remain unchanged. These are bug fixes and internal improvements.

https://claude.ai/code/session_01BEDYrGgmB2ehTS95XkXqBJ