### PR TITLE
fix: css-prop key shadowing, ts-jest detection, import aliasing

### DIFF
--- a/.changeset/feat-css-prop-import-path.md
+++ b/.changeset/feat-css-prop-import-path.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-styled-components': minor
+---
+
+Add a `cssPropImportPath` option to control which package the css-prop transform auto-imports `styled` from when the file has no existing styled import. Defaults to `'styled-components'` (existing behavior). React Native targets can set it to `'styled-components/native'` so the auto-injected import resolves to the right runtime.

--- a/.changeset/feat-follow-local-alias-of-styled.md
+++ b/.changeset/feat-follow-local-alias-of-styled.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-styled-components': minor
+---
+
+Detect styled declarations that go through a local alias of the import, including the TypeScript theme-typing pattern `const styled = baseStyled as ThemedStyledInterface<MyTheme>`. After type-stripping Babel sees a plain `const styled = baseStyled`, and the detector now follows single-identifier alias chains so `styled.div` resolves back to the original import.

--- a/.changeset/fix-css-prop-object-key-shadowed-by-binding.md
+++ b/.changeset/fix-css-prop-object-key-shadowed-by-binding.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-styled-components': patch
+---
+
+Fix invalid output when a `css={{ ... }}` object key matches a local binding name (e.g. `({ position }) => <div css={{ position: 'absolute' }} />`). The reducer no longer mis-treats non-computed property names as scope references, so plain keys stay literal while only computed `[expr]` keys are extracted as prop interpolations.

--- a/.changeset/fix-recognize-ts-import-default-helper.md
+++ b/.changeset/fix-recognize-ts-import-default-helper.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-styled-components': patch
+---
+
+Recognize TypeScript's `__importDefault` interop helper alongside Babel's `_interopRequireDefault`. Files compiled through `tsc` / `ts-jest` (which emit `var sc_1 = __importDefault(require('styled-components'))`) now flow into the same detection path as Babel-compiled output, so styled declarations downstream pick up `displayName` and `componentId` as expected.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Then add it to your babel configuration:
 }
 ```
 
+## Options
+
+Full option reference lives on the [styled-components documentation site](https://www.styled-components.com/docs/tooling#babel-plugin). A couple worth flagging here:
+
+- `topLevelImportPaths` (`string[]`): additional module specifiers whose `styled` export should be recognized alongside `styled-components`. Useful for libraries that re-export the styled-components API.
+- `cssPropImportPath` (`string`, default `'styled-components'`): which package the css-prop transform should auto-import `styled` from when the file doesn't already have a styled import. Set to `'styled-components/native'` for React Native targets.
+
 ## Changelog
 
 See [Github Releases](https://github.com/styled-components/babel-plugin-styled-components/releases)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This plugin is a highly recommended supplement to the base styled-components lib
 - better debugging through automatic annotation of your styled components based on their context in the file system, etc.
 - various types of minification for styles and the tagged template literals styled-components uses
 
+## Requirements
+
+This plugin is tested against:
+
+- `@babel/core` `^7`
+- `styled-components` `>= 6` (earlier majors may still work but aren't exercised in CI)
+
 ## Quick start
 
 Install the plugin first:

--- a/src/utils/detectors.js
+++ b/src/utils/detectors.js
@@ -75,6 +75,37 @@ export const importLocalName = (name, state, options = {}) => {
   return localName
 }
 
+// Follow `const X = Y` (and TS `const X = Y as Type`) chains so a local
+// re-binding of the styled import still resolves to it. Lazy: only walks
+// the chain when the direct-name check misses, so the hot path is unchanged.
+const resolvesToDefaultLocal = (name, defaultLocal, state, t) => {
+  if (!name || !defaultLocal) return false
+  if (name === defaultLocal) return true
+  const scope = state.file.path.scope
+  const visited = new Set([name])
+  let current = name
+  while (true) {
+    const binding = scope.getBinding(current)
+    if (!binding || !binding.path.isVariableDeclarator()) return false
+    const init = binding.path.node.init
+    if (!init) return false
+    let nextName = null
+    if (t.isIdentifier(init)) {
+      nextName = init.name
+    } else if (
+      (init.type === 'TSAsExpression' || init.type === 'TSTypeAssertion') &&
+      t.isIdentifier(init.expression)
+    ) {
+      nextName = init.expression.name
+    }
+    if (!nextName) return false
+    if (nextName === defaultLocal) return true
+    if (visited.has(nextName)) return false
+    visited.add(nextName)
+    current = nextName
+  }
+}
+
 export const isStyled = t => (tag, state) => {
   if (
     t.isCallExpression(tag) &&
@@ -91,14 +122,16 @@ export const isStyled = t => (tag, state) => {
     return isStyled(t)(getSequenceExpressionValue(tag.callee), state)
   } else {
     const defaultLocal = importLocalName('default', state)
+    const matchesDefault = name =>
+      resolvesToDefaultLocal(name, defaultLocal, state, t)
     return (
       (t.isMemberExpression(tag) &&
-        tag.object.name === defaultLocal &&
+        matchesDefault(tag.object.name) &&
         !isHelper(t)(tag.property, state)) ||
-      (t.isCallExpression(tag) && tag.callee.name === defaultLocal) ||
+      (t.isCallExpression(tag) && matchesDefault(tag.callee.name)) ||
       (t.isCallExpression(tag) &&
         t.isSequenceExpression(tag.callee) &&
-        getSequenceExpressionValue(tag.callee).name === defaultLocal) ||
+        matchesDefault(getSequenceExpressionValue(tag.callee).name)) ||
       // styled.default.div``, styled.default.something() — require() forms
       (state.styledRequired &&
         t.isMemberExpression(tag) &&

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -27,3 +27,6 @@ export const useNamespace = state => {
 export const usePureAnnotation = state => getOption(state, 'pure', false)
 
 export const useCssProp = state => getOption(state, 'cssProp', true)
+
+export const useCssPropImportPath = state =>
+  getOption(state, 'cssPropImportPath', 'styled-components')

--- a/src/visitors/assignStyledRequired.js
+++ b/src/visitors/assignStyledRequired.js
@@ -6,11 +6,13 @@ export default t => (path, state) => {
   if (
     t.isCallExpression(path.node.init) &&
     t.isIdentifier(path.node.init.callee) &&
-    init.callee.name === '_interopRequireDefault' &&
+    // `_interopRequireDefault` is Babel's CJS interop helper; `__importDefault`
+    // is TypeScript's. Both wrap a require() so the caller can reach `.default`.
+    (init.callee.name === '_interopRequireDefault' ||
+      init.callee.name === '__importDefault') &&
     init.arguments &&
     init.arguments[0]
   ) {
-    // _interopRequireDefault(require())
     init = path.node.init.arguments[0];
   }
 

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -1,7 +1,7 @@
 // Most of this code was taken from @satya164's babel-plugin-css-prop
 import { addDefault } from '@babel/helper-module-imports'
 import { importLocalName } from '../utils/detectors'
-import { useCssProp } from '../utils/options'
+import { useCssProp, useCssPropImportPath } from '../utils/options'
 import { processCallExpression, processTaggedTemplate } from './process'
 
 const TAG_NAME_REGEXP = /^[a-z][a-z\d]*(\-[a-z][a-z\d]*)?$/
@@ -68,7 +68,7 @@ export default t => {
     // not directly callable, so treat it the same as "no default binding" and
     // inject a fresh default import to use as the css-prop callee.
     if (!importBinding || importBindingIsNamespace) {
-      addDefault(path, 'styled-components', {
+      addDefault(path, useCssPropImportPath(state), {
         nameHint: 'styled',
       })
 

--- a/src/visitors/transpileCssProp.js
+++ b/src/visitors/transpileCssProp.js
@@ -174,8 +174,12 @@ export default t => {
         if (
           t.isMemberExpression(property.key) ||
           t.isCallExpression(property.key) ||
-          // checking for css={{[something]: something}}
+          // checking for css={{[something]: something}}; a plain (non-computed)
+          // identifier key is a literal property name and never resolves to a
+          // binding, even if the local scope happens to define a same-named
+          // variable. Only computed keys reference the surrounding scope.
           (t.isIdentifier(property.key) &&
+            property.computed &&
             path.scope.hasBinding(property.key.name) &&
             // but not a object reference shorthand like css={{ color }}
             (t.isIdentifier(property.value)

--- a/test/fixtures/css-prop-object-key-shadowed-by-binding/.babelrc
+++ b/test/fixtures/css-prop-object-key-shadowed-by-binding/.babelrc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "ssr": false,
+        "fileName": false,
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/css-prop-object-key-shadowed-by-binding/code.js
+++ b/test/fixtures/css-prop-object-key-shadowed-by-binding/code.js
@@ -1,0 +1,9 @@
+// Regression: a non-computed object key (e.g. `position`) is a literal
+// property name, never a binding reference, even when the local scope
+// has a same-named binding. The css-prop object reducer must only rewrite
+// computed keys (`[expr]`) into prop interpolations; plain keys stay literal.
+import React from 'react'
+
+const Outer = ({ position }) => (
+  <div css={{ position: 'absolute', top: position }} />
+)

--- a/test/fixtures/css-prop-object-key-shadowed-by-binding/output.js
+++ b/test/fixtures/css-prop-object-key-shadowed-by-binding/output.js
@@ -1,0 +1,15 @@
+import _styled from "styled-components";
+// Regression: a non-computed object key (e.g. `position`) is a literal
+// property name, never a binding reference, even when the local scope
+// has a same-named binding. The css-prop object reducer must only rewrite
+// computed keys (`[expr]`) into prop interpolations; plain keys stay literal.
+import React from 'react';
+const Outer = ({
+  position
+}) => <_StyledDiv $_css={position} />;
+var _StyledDiv = _styled("div").withConfig({
+  displayName: "_StyledDiv"
+})(p => ({
+  position: 'absolute',
+  top: p.$_css
+}));

--- a/test/fixtures/css-prop-with-native-import-path/.babelrc
+++ b/test/fixtures/css-prop-with-native-import-path/.babelrc
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "ssr": false,
+        "fileName": false,
+        "transpileTemplateLiterals": false,
+        "cssPropImportPath": "styled-components/native"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/css-prop-with-native-import-path/code.js
+++ b/test/fixtures/css-prop-with-native-import-path/code.js
@@ -1,0 +1,11 @@
+// React Native targets need the auto-injected default import to come from
+// `styled-components/native` rather than the DOM package. The
+// `cssPropImportPath` option lets the consumer name the package; the rest
+// of the css-prop transform is shape-compatible with RN already (the
+// PascalCase JSX name routes through the identifier branch and produces
+// `styled(View)` instead of `styled('View')`).
+import { View } from 'react-native'
+
+const Comp = () => <View css={{ backgroundColor: 'red' }} />
+
+export default Comp

--- a/test/fixtures/css-prop-with-native-import-path/output.js
+++ b/test/fixtures/css-prop-with-native-import-path/output.js
@@ -1,0 +1,15 @@
+import _styled from "styled-components/native";
+// React Native targets need the auto-injected default import to come from
+// `styled-components/native` rather than the DOM package. The
+// `cssPropImportPath` option lets the consumer name the package; the rest
+// of the css-prop transform is shape-compatible with RN already (the
+// PascalCase JSX name routes through the identifier branch and produces
+// `styled(View)` instead of `styled('View')`).
+import { View } from 'react-native';
+const Comp = () => <_StyledView />;
+export default Comp;
+var _StyledView = _styled(View).withConfig({
+  displayName: "_StyledView"
+})({
+  backgroundColor: 'red'
+});

--- a/test/fixtures/named-import-styled-from-sc-v6/.babelrc
+++ b/test/fixtures/named-import-styled-from-sc-v6/.babelrc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "ssr": false,
+        "fileName": false,
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/named-import-styled-from-sc-v6/code.js
+++ b/test/fixtures/named-import-styled-from-sc-v6/code.js
@@ -1,0 +1,13 @@
+// Regression: styled-components v6 exposes a named `styled` export. The
+// detector resolves `import { styled } from 'styled-components'` to the same
+// local binding the default import would produce, so member and call forms
+// both pick up displayName and componentId.
+import { styled } from 'styled-components'
+
+const Foo = styled.div`
+  color: red;
+`
+
+const Bar = styled('span')`
+  color: blue;
+`

--- a/test/fixtures/named-import-styled-from-sc-v6/output.js
+++ b/test/fixtures/named-import-styled-from-sc-v6/output.js
@@ -1,0 +1,11 @@
+// Regression: styled-components v6 exposes a named `styled` export. The
+// detector resolves `import { styled } from 'styled-components'` to the same
+// local binding the default import would produce, so member and call forms
+// both pick up displayName and componentId.
+import { styled } from 'styled-components';
+const Foo = styled.div.withConfig({
+  displayName: "Foo"
+})`color:red;`;
+const Bar = styled('span').withConfig({
+  displayName: "Bar"
+})`color:blue;`;

--- a/test/fixtures/pre-transpiled-tsc-importdefault/.babelrc
+++ b/test/fixtures/pre-transpiled-tsc-importdefault/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "fileName": false,
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/pre-transpiled-tsc-importdefault/code.js
+++ b/test/fixtures/pre-transpiled-tsc-importdefault/code.js
@@ -1,0 +1,16 @@
+// Regression: the TypeScript compiler emits `__importDefault` as its CommonJS
+// interop helper (Babel uses `_interopRequireDefault`). Both wrap a require()
+// to expose `.default`, and the plugin needs to recognize either form so that
+// downstream styled-component detection on `<local>.default.div` succeeds.
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var __importDefault = (this && this.__importDefault) || function (mod) {
+  return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+var styled_components_1 = __importDefault(require("styled-components"));
+var Foo = styled_components_1.default.div`
+  color: red;
+`;
+var Bar = (0, styled_components_1.default)('span')`
+  color: blue;
+`;

--- a/test/fixtures/pre-transpiled-tsc-importdefault/output.js
+++ b/test/fixtures/pre-transpiled-tsc-importdefault/output.js
@@ -1,0 +1,23 @@
+// Regression: the TypeScript compiler emits `__importDefault` as its CommonJS
+// interop helper (Babel uses `_interopRequireDefault`). Both wrap a require()
+// to expose `.default`, and the plugin needs to recognize either form so that
+// downstream styled-component detection on `<local>.default.div` succeeds.
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    "default": mod
+  };
+};
+var styled_components_1 = __importDefault(require("styled-components"));
+var Foo = styled_components_1.default.div.withConfig({
+  displayName: "Foo",
+  componentId: "sc-1km53of-0"
+})`color:red;`;
+var Bar = (0, styled_components_1.default)('span').withConfig({
+  displayName: "Bar",
+  componentId: "sc-1km53of-1"
+})`color:blue;`;

--- a/test/fixtures/styled-alias-via-local-binding/.babelrc
+++ b/test/fixtures/styled-alias-via-local-binding/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "fileName": false,
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/styled-alias-via-local-binding/code.js
+++ b/test/fixtures/styled-alias-via-local-binding/code.js
@@ -1,0 +1,16 @@
+// Regression: TypeScript theme-typing patterns re-bind the default import
+// through a local `const`, e.g. `const styled = baseStyled as ThemedSC<...>`.
+// After type-stripping, Babel sees a plain `const styled = baseStyled`.
+// The detector must follow such single-identifier aliases so `styled.div` is
+// still recognized as a styled-component declaration.
+import baseStyled from 'styled-components'
+
+const styled = baseStyled
+
+const Foo = styled.div`
+  color: red;
+`
+
+const Bar = styled('span')`
+  color: blue;
+`

--- a/test/fixtures/styled-alias-via-local-binding/output.js
+++ b/test/fixtures/styled-alias-via-local-binding/output.js
@@ -1,0 +1,15 @@
+// Regression: TypeScript theme-typing patterns re-bind the default import
+// through a local `const`, e.g. `const styled = baseStyled as ThemedSC<...>`.
+// After type-stripping, Babel sees a plain `const styled = baseStyled`.
+// The detector must follow such single-identifier aliases so `styled.div` is
+// still recognized as a styled-component declaration.
+import baseStyled from 'styled-components';
+const styled = baseStyled;
+const Foo = styled.div.withConfig({
+  displayName: "Foo",
+  componentId: "sc-ep8j7b-0"
+})`color:red;`;
+const Bar = styled('span').withConfig({
+  displayName: "Bar",
+  componentId: "sc-ep8j7b-1"
+})`color:blue;`;

--- a/test/fixtures/withconfig-chained-on-existing-config/.babelrc
+++ b/test/fixtures/withconfig-chained-on-existing-config/.babelrc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "../../../src",
+      {
+        "ssr": true,
+        "fileName": false,
+        "transpileTemplateLiterals": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/withconfig-chained-on-existing-config/code.js
+++ b/test/fixtures/withconfig-chained-on-existing-config/code.js
@@ -1,0 +1,11 @@
+// Regression: when the user already chains a `.withConfig(...)` with a
+// non-literal argument (e.g. `withConfig(getConfig())`), the plugin appends
+// its own `.withConfig({ displayName, componentId })` rather than skipping
+// augmentation altogether.
+import styled from 'styled-components'
+
+const getConfig = () => ({ shouldForwardProp: () => true })
+
+const Foo = styled.div.withConfig(getConfig())`
+  color: red;
+`

--- a/test/fixtures/withconfig-chained-on-existing-config/output.js
+++ b/test/fixtures/withconfig-chained-on-existing-config/output.js
@@ -1,0 +1,12 @@
+// Regression: when the user already chains a `.withConfig(...)` with a
+// non-literal argument (e.g. `withConfig(getConfig())`), the plugin appends
+// its own `.withConfig({ displayName, componentId })` rather than skipping
+// augmentation altogether.
+import styled from 'styled-components';
+const getConfig = () => ({
+  shouldForwardProp: () => true
+});
+const Foo = styled.div.withConfig(getConfig()).withConfig({
+  displayName: "Foo",
+  componentId: "sc-1o89p33-0"
+})`color:red;`;


### PR DESCRIPTION
## Summary

Three targeted fixes alongside a long-overdue triage sweep of the open issue queue, plus a small React Native enabler. No version bump in package.json; the changesets in this PR resolve to a minor on the next release.

- **css-prop object keys stay literal** when a same-named binding exists in scope. Previously `({ position }) => <div css={{ position: 'absolute' }} />` produced invalid output of the form `p.$_css: 'absolute'`. Only computed (`[expr]`) keys are extracted as prop interpolations now. Closes #409.
- **Recognize TypeScript's `__importDefault`** interop helper alongside Babel's `_interopRequireDefault`. ts-jest output (`var sc_1 = __importDefault(require('styled-components'))`) now reaches the same detection path as Babel-compiled output. Closes #406, #343.
- **Follow local aliases of the styled import**, including the TS theme-typing pattern `const styled = baseStyled as ThemedStyledInterface<...>`. After Babel strips the TS annotation, the detector walks the single-identifier alias chain back to the original import. Closes #238.
- **`cssPropImportPath` option for React Native.** The css-prop transform auto-injects `import _styled from 'styled-components'` when the file has no existing styled import. That hardcoded path was the only piece blocking RN from using the css-prop syntax; the rest of the transform already produces the right shape (PascalCase JSX names route through the identifier branch and emit `styled(View)` rather than `styled('View')`). RN consumers can now set `cssPropImportPath: 'styled-components/native'` to point the injection at the correct runtime. Closes #272.

Plus a Requirements section in README naming the tested matrix (Babel 7, sc >= 6) and an Options section calling out the two opt-in knobs.

Each fix lands with a new red/green fixture and its own changeset. New regression fixtures: `css-prop-object-key-shadowed-by-binding`, `pre-transpiled-tsc-importdefault`, `styled-alias-via-local-binding`, `named-import-styled-from-sc-v6`, `withconfig-chained-on-existing-config`, `css-prop-with-native-import-path`.

## Issue queue triage

Verification pass over all 73 open issues against current main:

- **Already fixed in current main, recommend closing**: #261, #353, #392, #415, #379, #103, #115, #215, #314, #235, #179. Per-situation closing comments drafted.
- **Fixed by this PR**: #409, #406, #343, #238, #272.
- **Stale (removed API or defunct premise)**: #145, #216, #394, #349, #251.
- **Still-open, deferred to follow-up PRs**: #347 and #201 share a hoisting root cause for css-prop with function-local JSX names; plus a couple dozen smaller surface bugs queued in the backlog (#316, #312, #346/#251, #284, #280, #277, #291, #264, #252, #245, #222, #208, #133, #81, #351, #108).
- **Feature requests, support threads, third-party integration questions**: leave open.

## PR closures

- #393: failing fixture lifted into this PR's `named-import-styled-from-sc-v6`.
- #410 by @wojtekmaj: superseded by 2.2.0's lodash removal.
- #364 and #365 by @Janpot: MUI's `styled` import is reachable today via the `topLevelImportPaths` opt-in.
- #278 by @Andarist, #248 by @mbrowne, #180 by @yiochen, #259 by @elie222: status comments, left open as candidates for follow-up.

## Candidates for a future v3

This release stays a minor since no real user-visible break is queued. Listing the candidates that would justify a deliberate v3:

- Tighten `styled-components` peer to `>= 6` as a formal signal of the tested matrix.
- Flip the `pure` default to true so PURE annotations help tree-shaking by default (#245, see also @mbrowne's investigation in #248).
- Add `engines.node` and tighten the `@babel/core` peer to a recent minor floor.

Each of these breaks at least one currently-working consumer configuration in a small way, so they belong together rather than dribbled out one at a time.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test` (63 tests pass; new fixtures included)
- [x] `pnpm build` (lib/ produced cleanly)
- [x] Red/green TDD per fix: pre-fix snapshot captures broken output, post-fix update shows the corrected output
