### PR TITLE
Add bugs metadata

### DIFF
--- a/.changeset/blue-buttons-report.md
+++ b/.changeset/blue-buttons-report.md
@@ -1,0 +1,5 @@
+---
+"babel-plugin-styled-components": patch
+---
+
+Add npm bugs metadata pointing to the GitHub issue tracker.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Improve the debugging experience and add server-side rendering support to styled-components",
   "repository": "styled-components/babel-plugin-styled-components",
   "homepage": "https://styled-components.com/docs/tooling#babel-plugin",
+  "bugs": {
+    "url": "https://github.com/styled-components/babel-plugin-styled-components/issues"
+  },
   "contributors": [
     "Vladimir Danchenkov <vladimir.danchenkov@gmail.com>",
     "Max Stoiber <contact@mxstbr.com>",


### PR DESCRIPTION
## Summary

- add standard npm `bugs.url` metadata pointing to this repository's issue tracker
- add a changeset so the package metadata update can be published

The published package currently exposes homepage and repository metadata, but does not expose a usable `bugs` link in npm package metadata.

## Verification

- `node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2)); if(p.name!=='babel-plugin-styled-components'||p.bugs?.url!=='https://github.com/styled-components/babel-plugin-styled-components/issues') process.exit(1)"`
- `git diff --check`